### PR TITLE
Add license information to package metadata

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -66,7 +66,9 @@ setup(name=name,
       install_requires={requires},
       packages={packages},
       package_data={package_data},
+      license="Apache-2.0 license",
       classifiers=[
+          "License :: OSI Approved :: Apache Software License",
           "Typing :: Typed",
       ]
 )


### PR DESCRIPTION
This PR adds license information to the generated packages as explained in [typeshed issue #5263](https://github.com/python/typeshed/issues/5263).

As mentioned in the issue, typeshed is licensed partially under Apache and partially under MIT. I opted to add the Apache License since it is the most restrictive of both, but IANAL :)