### PR TITLE
Create an sdist for every wheel that is built

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -369,6 +369,7 @@ def main(typeshed_dir: str, distribution: str, increment: int) -> str:
     current_dir = os.getcwd()
     os.chdir(tmpdir)
     subprocess.run(["python3", "setup.py", "bdist_wheel", "--universal"])
+    subprocess.run(["python3", "setup.py", "sdist"])
     os.chdir(current_dir)
     return f"{tmpdir}/dist"
 


### PR DESCRIPTION
Some users prefer to build their own wheels, and the fact that the
modular types packages are only uploaded as wheels means that these
users can't use pip with "--no-binary :all:" to guarantee that pip only
downloads sdists in order to then rebuild the corresponding wheel.