### PR TITLE
Remove 'auto-generated' from package description

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -77,7 +77,7 @@ package if you use this or a newer version.
 DESCRIPTION_INTRO_TEMPLATE = """
 ## Typing stubs for {distribution}
 
-This is a PEP 561 type stub package for `{distribution}` package.
+This is a PEP 561 type stub package for the `{distribution}` package.
 It can be used by type-checking tools like mypy, PyCharm, pytype etc. to check code
 that uses `{distribution}`. The source for this package can be found at
 https://github.com/python/typeshed/tree/master/stubs/{distribution}. All fixes for

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -77,7 +77,7 @@ package if you use this or a newer version.
 DESCRIPTION_INTRO_TEMPLATE = """
 ## Typing stubs for {distribution}
 
-This is an auto-generated PEP 561 type stub package for `{distribution}` package.
+This is a PEP 561 type stub package for `{distribution}` package.
 It can be used by type-checking tools like mypy, PyCharm, pytype etc. to check code
 that uses `{distribution}`. The source for this package can be found at
 https://github.com/python/typeshed/tree/master/stubs/{distribution}. All fixes for


### PR DESCRIPTION
While the package is of course auto-generated, this could give the wrong impression that the *stubs* are auto-generated and hence low quality.