### PR TITLE
Fix package renames

### DIFF
--- a/scripts/get_changed.py
+++ b/scripts/get_changed.py
@@ -17,7 +17,7 @@ from typing import List
 def main(typeshed_dir: str, commit: str) -> List[str]:
     """List all distributions that changed since commit."""
     assert typeshed_dir.endswith(os.sep + "typeshed")
-    git = subprocess.run(["git", "diff", "--name-only", "HEAD", commit],
+    git = subprocess.run(["git", "diff", "--no-renames", "--name-only", "HEAD", commit],
                          capture_output=True, universal_newlines=True, cwd=typeshed_dir, check=True)
     changed = set()
     for file in git.stdout.splitlines():


### PR DESCRIPTION
Previously, when a package was renamed, "git diff --name-only" did not
list the target name, only the source name, causing it not to upload a
new package.