### PR TITLE
Create and commit changelogs

### DIFF
--- a/.github/workflows/update_stubs.yml
+++ b/.github/workflows/update_stubs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: "3.9"
       - name: Checkout main
         uses: actions/checkout@v2
         with:
@@ -43,4 +43,5 @@ jobs:
               exit 0;
           fi
           git config user.name github-actions && git config user.email github-actions@github.com
+          # This will also commit any new and changed changelogs.
           git add . && git commit -m "Update last typeshed commit" && git push

--- a/scripts/const.py
+++ b/scripts/const.py
@@ -1,0 +1,4 @@
+THIRD_PARTY_NAMESPACE = "stubs"
+PY2_NAMESPACE = "@python2"
+TESTS_NAMESPACE = "@tests"
+META = "METADATA.toml"

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -19,7 +19,8 @@ import toml
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry  # type: ignore[import]
 
-THIRD_PARTY_NAMESPACE = "stubs"
+from scripts.const import *
+
 PREFIX = "types-"
 URL_TEMPLATE = "https://pypi.org/pypi/{}/json"
 RETRIES = 5

--- a/scripts/metadata.py
+++ b/scripts/metadata.py
@@ -1,0 +1,30 @@
+import os
+from typing import Any, Dict
+
+import toml
+
+from scripts import get_version
+
+from .const import META, THIRD_PARTY_NAMESPACE
+
+
+Metadata = Dict[str, Any]
+
+
+def read_metadata(typeshed_dir: str, distribution: str) -> Metadata:
+    """Parse metadata from file."""
+    file = os.path.join(typeshed_dir, THIRD_PARTY_NAMESPACE, distribution, META)
+    with open(file) as f:
+        return dict(toml.loads(f.read()))
+
+
+def determine_version(typeshed_dir: str, distribution: str) -> str:
+    metadata = read_metadata(typeshed_dir, distribution)
+    version: str = metadata["version"]
+    assert version.count(".") == 1, f"Version must be major.minor, not {version}"
+    # Setting base version to None, so it will be read from current METADATA.toml.
+    increment = get_version.main(typeshed_dir, distribution, None)
+    if increment >= 0:
+        print(f"Existing version found for {distribution}")
+    increment += 1
+    return f"{version}.{increment}"

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""
+This script updates the changelog for a single module.
+"""
+
+import argparse
+import datetime
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+THIRD_PARTY_NAMESPACE = "stubs"
+CHANGELOGS = "data/changelogs"
+
+
+def main() -> None:
+    args = parse_args()
+    update_changelog(
+        args.typeshed_dir, args.previous_commit, args.distribution, args.version, dry_run=args.dry_run,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("typeshed_dir", help="Path to typeshed checkout directory")
+    parser.add_argument("previous_commit", help="Previous typeshed commit for which we performed upload")
+    parser.add_argument("distribution", help="Distribution to update the changelog for")
+    parser.add_argument("version", help="New version to add to the changelog")
+    parser.add_argument("--dry-run", action="store_true", help="Should we perform a dry run (don't actually update)")
+    return parser.parse_args()
+
+
+def update_changelog(
+    typeshed_dir: str, previous_commit: str, distribution: str, version: str, *, dry_run: bool = False,
+) -> None:
+    dist_path = Path(THIRD_PARTY_NAMESPACE, distribution)
+    result = subprocess.run(
+        ["git", "log", f"{previous_commit}..HEAD", "--", dist_path],
+        cwd=typeshed_dir,
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    log = result.stdout.decode("utf-8")
+    if not log:
+        print(f"{distribution}: Changelog unchanged")
+        return
+    new_entry = process_git_log(log, version)
+
+    changelog = os.path.join(CHANGELOGS, f"{distribution}.md")
+    try:
+        with open(changelog) as f:
+            old_entries = f.read()
+    except FileNotFoundError:
+        old_entries = ""
+
+    if dry_run:
+        if old_entries:
+            print(f"Would add {len(new_entry.splitlines())} lines to existing {changelog}")
+        else:
+            print(f"Would add {len(new_entry.splitlines())} lines to new {changelog}")
+        return
+
+    with open(changelog, "w") as f:
+        f.write(new_entry + old_entries)
+
+
+def process_git_log(log: str, version: str) -> str:
+    today = datetime.date.today()
+    entry = f"## {version} ({today:%Y-%m-%d})\n"
+    for line in log.splitlines():
+        if line.strip() == "":
+            entry += "\n"
+        elif line.startswith("    "):
+            # Proper git log lines start with four spaces.
+            entry += f"{line.rstrip()[4:]}\n"
+        else:
+            pass # Ignore header entries.
+    entry += "\n"
+    # Strip multiple empty lines.
+    return re.sub("\n\n+", "\n\n", entry)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/upload_changed.py
+++ b/scripts/upload_changed.py
@@ -13,7 +13,7 @@ import argparse
 import os
 import subprocess
 
-from scripts import build_wheel, get_changed
+from scripts import build_wheel, get_changed, update_changelog
 from scripts.metadata import determine_version, read_metadata
 
 
@@ -30,6 +30,7 @@ def main(typeshed_dir: str, commit: str, uploaded: str, dry_run: bool = False) -
     print("Building and uploading stubs for:", ", ".join(to_upload))
     for distribution in to_upload:
         version = determine_version(typeshed_dir, distribution)
+        update_changelog.update_changelog(typeshed_dir, commit, distribution, version, dry_run=dry_run)
         temp_dir = build_wheel.main(typeshed_dir, distribution, version)
         if dry_run:
             print(f"Would upload: {distribution}, version {version}")

--- a/scripts/upload_some.py
+++ b/scripts/upload_some.py
@@ -13,8 +13,8 @@ import os
 import re
 import subprocess
 
-from scripts import get_version
 from scripts import build_wheel
+from scripts.metadata import determine_version, read_metadata
 
 
 def main(typeshed_dir: str, pattern: str, uploaded: str) -> None:
@@ -29,16 +29,10 @@ def main(typeshed_dir: str, pattern: str, uploaded: str) -> None:
     )
     print("Uploading stubs for:", ", ".join(to_upload))
     for distribution in to_upload:
-        # Setting base version to None, so it will be read from current METADATA.toml.
-        increment = get_version.main(typeshed_dir, distribution, version=None)
-        increment += 1
-        for dependency in build_wheel.read_metadata(
-            os.path.join(
-                typeshed_dir, build_wheel.THIRD_PARTY_NAMESPACE, distribution, build_wheel.META
-            )
-        ).get("requires", []):
+        version = determine_version(typeshed_dir, distribution)
+        for dependency in read_metadata(typeshed_dir, distribution).get("requires", []):
             build_wheel.verify_dependency(typeshed_dir, dependency, uploaded)
-        temp_dir = build_wheel.main(typeshed_dir, distribution, increment)
+        temp_dir = build_wheel.main(typeshed_dir, distribution, version)
         subprocess.run(["twine", "upload", os.path.join(temp_dir, "*")], check=True)
         build_wheel.update_uploaded(uploaded, distribution)
         print(f"Successfully uploaded stubs for {distribution}")

--- a/scripts/upload_some.py
+++ b/scripts/upload_some.py
@@ -32,6 +32,7 @@ def main(typeshed_dir: str, pattern: str, uploaded: str) -> None:
         version = determine_version(typeshed_dir, distribution)
         for dependency in read_metadata(typeshed_dir, distribution).get("requires", []):
             build_wheel.verify_dependency(typeshed_dir, dependency, uploaded)
+        # TODO: Update changelog
         temp_dir = build_wheel.main(typeshed_dir, distribution, version)
         subprocess.run(["twine", "upload", os.path.join(temp_dir, "*")], check=True)
         build_wheel.update_uploaded(uploaded, distribution)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,6 +6,7 @@ a typeshed checkout side by side.
 import os
 import pytest  # type: ignore[import]
 from scripts import get_version, build_wheel
+from scripts.metadata import read_metadata
 
 TYPESHED = "../typeshed"
 UPLOADED = "data/uploaded_packages.txt"
@@ -27,7 +28,7 @@ def test_check_exists() -> None:
 def test_build_wheel() -> None:
     """Check that we can build wheels for all distributions."""
     for distribution in os.listdir(os.path.join(TYPESHED, "stubs")):
-        tmp_dir = build_wheel.main(TYPESHED, distribution, increment=1)
+        tmp_dir = build_wheel.main(TYPESHED, distribution, version="1.1.1")
         assert tmp_dir.endswith("/dist")
         assert list(os.listdir(tmp_dir))  # check it is not empty
 
@@ -53,11 +54,7 @@ def test_dependency_order() -> None:
     )
     assert len(set(to_upload)) == len(to_upload)
     for distribution in distributions:
-        for dependency in build_wheel.read_metadata(
-            os.path.join(
-                TYPESHED, build_wheel.THIRD_PARTY_NAMESPACE, distribution, build_wheel.META
-            )
-        ).get("requires", []):
+        for dependency in read_metadata(TYPESHED, distribution).get("requires", []):
             assert to_upload.index(
                 build_wheel.strip_types_prefix(get_version.strip_dep_version(dependency))
             ) < to_upload.index(distribution)


### PR DESCRIPTION
This is a first step for python/typeshed#5633. The current
implementation generates and commits the changelogs, but
doesn't add them to the generated packages.