### PR TITLE
Use strict mypy over codebase

### DIFF
--- a/.github/workflows/check_scripts.yml
+++ b/.github/workflows/check_scripts.yml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
       - uses: actions/checkout@v2
-      - run: pip install mypy types-requests types-toml
-      - run: mypy -p scripts -p tests
+      - run: pip install mypy types-requests types-toml pytest
+      - run: mypy --strict -p scripts -p tests
 
   tests:
     name: Run integration and unit tests

--- a/scripts/get_version.py
+++ b/scripts/get_version.py
@@ -12,7 +12,7 @@ distribution information.
 
 import argparse
 import os.path
-from typing import Optional
+from typing import Optional, cast
 
 import requests
 import toml
@@ -35,7 +35,7 @@ def read_base_version(typeshed_dir: str, distribution: str) -> str:
     )
     with open(metadata_file) as f:
         data = toml.loads(f.read())
-    return data["version"]
+    return cast(str, data["version"])
 
 
 def strip_dep_version(dependency: str) -> str:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -4,7 +4,7 @@ anything on PyPI, but can make PyPI queries and may expect
 a typeshed checkout side by side.
 """
 import os
-import pytest  # type: ignore[import]
+import pytest
 from scripts import get_version, build_wheel
 from scripts.metadata import read_metadata
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,7 +1,7 @@
 """Unit tests for simple helpers should go here."""
 
 import os
-import pytest  # type: ignore[import]
+import pytest
 from scripts.get_version import strip_dep_version
 from scripts.build_wheel import collect_setup_entries, sort_by_dependency, transitive_deps, strip_types_prefix, SUFFIX, PY2_SUFFIX
 


### PR DESCRIPTION
pytest is now annotated, so no longer need type ignores.