### PR TITLE
Fix for versions ending with asterisk

### DIFF
--- a/scripts/metadata.py
+++ b/scripts/metadata.py
@@ -19,10 +19,8 @@ def read_metadata(typeshed_dir: str, distribution: str) -> Metadata:
 
 
 def determine_version(typeshed_dir: str, distribution: str) -> str:
-    metadata = read_metadata(typeshed_dir, distribution)
-    version: str = metadata["version"]
-    # Setting base version to None, so it will be read from current METADATA.toml.
-    increment = get_version.main(typeshed_dir, distribution, None)
+    version = get_version.read_base_version(typeshed_dir, distribution)
+    increment = get_version.main(typeshed_dir, distribution, version)
     if increment >= 0:
         print(f"Existing version found for {distribution}")
     increment += 1


### PR DESCRIPTION
See https://github.com/python/typeshed/commit/9f869723509ac027bae6b6f567b921d6a229e8ec#commitcomment-57843207
cc @srittau 