### PR TITLE
Link the packages and the script that generated them

### DIFF
--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -84,6 +84,9 @@ types and metadata should be contributed there.
 DESCRIPTION_OUTRO_TEMPLATE = """
 See https://github.com/python/typeshed/blob/master/README.md for more details.
 This package was generated from typeshed commit `{commit}`.
+The script that generated this package is maintained at
+https://github.com/typeshed-internal/stub_uploader, and it is run daily when
+stubs are updated.
 """.strip()
 
 


### PR DESCRIPTION
This script is responsible for quite a few important packages. This PR suggests adding an explicit link between this script and the packages it produces, so that one would be able to study how it works. I got the info by asking [here](https://github.com/python/typeshed/pull/6454#issuecomment-982674966) (thanks @Akuli)

We can also document the link in the `typeshed` README, and we can decide to do either or both. I would say that having a way to go from a project in PyPI to the code that generated it is always a good idea. That being said, it's not mandatory.

Thanks and have a nice day :)