### PR TITLE
Use the new "Typing :: Stubs Only" classifier

### DIFF
--- a/data/empty_package/setup.py
+++ b/data/empty_package/setup.py
@@ -14,6 +14,6 @@ setup(
     install_requires=[],
     packages=[],
     classifiers=[
-        "Typing :: Typed",
+        "Typing :: Stubs Only",
     ],
 )

--- a/scripts/build_wheel.py
+++ b/scripts/build_wheel.py
@@ -58,7 +58,7 @@ setup(name=name,
       license="Apache-2.0 license",
       classifiers=[
           "License :: OSI Approved :: Apache Software License",
-          "Typing :: Typed",
+          "Typing :: Stubs Only",
       ]
 )
 """


### PR DESCRIPTION
The new `Typing :: Stubs Only` classifier in [trove-classifiers==2022.1.3](https://pypi.org/project/trove-classifiers/2022.1.3/) is especially well suited for packages that don't provide typed code, but stubs for code that exists elsewhere.

Note that we'll need to wait for [warehouse](https://github.com/pypa/warehouse) to adopt this version of trove-classifiers before making the change, but this should arrive soon, as the PR will be crafted by dependabot quickly :)