### PR TITLE
Use tomli instead of toml

### DIFF
--- a/.github/workflows/check_scripts.yml
+++ b/.github/workflows/check_scripts.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: '3.9'
       - uses: actions/checkout@v2
-      - run: pip install mypy types-requests types-toml pytest
+      - run: pip install mypy types-requests pytest
       - run: mypy --strict -p stub_uploader -p tests
 
   tests:
@@ -46,6 +46,6 @@ jobs:
           path: typeshed
       - name: Run tests
         run: |
-          pip install pytest toml requests setuptools wheel
+          pip install pytest tomli requests setuptools wheel
           cd main
           python -m pytest tests

--- a/.github/workflows/force_update.yml
+++ b/.github/workflows/force_update.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine toml requests
+          pip install setuptools wheel twine tomli requests
       - name: Execute build and upload
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/update_stubs.yml
+++ b/.github/workflows/update_stubs.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine toml requests
+          pip install setuptools wheel twine tomli requests
       - name: Execute diff build and upload tasks
         env:
           TWINE_USERNAME: __token__

--- a/stub_uploader/get_version.py
+++ b/stub_uploader/get_version.py
@@ -19,7 +19,7 @@ from collections.abc import Iterable
 from typing import Any, Optional, cast
 
 import requests
-import toml
+import tomli
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -52,8 +52,8 @@ def read_base_version(typeshed_dir: str, distribution: str) -> str:
     metadata_file = os.path.join(
         typeshed_dir, THIRD_PARTY_NAMESPACE, distribution, "METADATA.toml"
     )
-    with open(metadata_file) as f:
-        data = toml.loads(f.read())
+    with open(metadata_file, "rb") as f:
+        data = tomli.load(f)
     version = data["version"]
     assert isinstance(version, str)
     if version.endswith(".*"):

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Dict
 
-import toml
+import tomli
 
 from stub_uploader import get_version
 
@@ -14,8 +14,8 @@ Metadata = Dict[str, Any]
 def read_metadata(typeshed_dir: str, distribution: str) -> Metadata:
     """Parse metadata from file."""
     file = os.path.join(typeshed_dir, THIRD_PARTY_NAMESPACE, distribution, META)
-    with open(file) as f:
-        return dict(toml.loads(f.read()))
+    with open(file, "rb") as f:
+        return dict(tomli.load(f))
 
 
 def determine_version(typeshed_dir: str, distribution: str) -> str:


### PR DESCRIPTION
tomli is actively maintained, supports TOML v1, is the basis for the
stdlib's tomllib in 3.11