### PR TITLE
Remove unused universal_args code

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -368,10 +368,7 @@ def main(
     copy_changelog(distribution, tmpdir)
     current_dir = os.getcwd()
     os.chdir(tmpdir)
-    universal_args = []
-    if metadata.get("version2", False):
-        universal_args.append("--universal")
-    subprocess.run(["python3", "setup.py", "bdist_wheel"] + universal_args)
+    subprocess.run(["python3", "setup.py", "bdist_wheel"])
     subprocess.run(["python3", "setup.py", "sdist"])
     os.chdir(current_dir)
     return f"{tmpdir}/dist"


### PR DESCRIPTION
As far as I'm aware, we've never had a "version2" attribute