### PR TITLE
Move around some "types-" prefix logic

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -103,9 +103,9 @@ class BuildData:
 
 def strip_types_prefix(dependency: str) -> str:
     assert dependency.startswith(
-        "types-"
+        TYPES_PREFIX
     ), "Currently only dependencies on stub packages are supported"
-    return dependency[len("types-") :]
+    return dependency[len(TYPES_PREFIX) :]
 
 
 def find_stub_files(top: str) -> List[str]:

--- a/stub_uploader/const.py
+++ b/stub_uploader/const.py
@@ -1,5 +1,6 @@
 THIRD_PARTY_NAMESPACE = "stubs"
 TESTS_NAMESPACE = "@tests"
 META = "METADATA.toml"
+TYPES_PREFIX = "types-"
 
 CHANGELOG_PATH = "data/changelogs"

--- a/stub_uploader/get_version.py
+++ b/stub_uploader/get_version.py
@@ -24,7 +24,6 @@ from urllib3.util.retry import Retry
 from stub_uploader.const import *
 from stub_uploader.metadata import Metadata
 
-PREFIX = "types-"
 URL_TEMPLATE = "https://pypi.org/pypi/{}/json"
 RETRIES = 5
 RETRY_ON = [429, 500, 502, 503, 504]
@@ -32,7 +31,8 @@ TIMEOUT = 3
 
 
 def fetch_pypi_versions(distribution: str) -> list[Version]:
-    url = URL_TEMPLATE.format(PREFIX + distribution)
+    assert distribution.startswith(TYPES_PREFIX)
+    url = URL_TEMPLATE.format(distribution)
     retry_strategy = Retry(total=RETRIES, status_forcelist=RETRY_ON)
     with requests.Session() as session:
         session.mount("https://", HTTPAdapter(max_retries=retry_strategy))
@@ -139,7 +139,7 @@ def strip_dep_version(dependency: str) -> str:
 
 
 def determine_incremented_version(metadata: Metadata) -> str:
-    published_stub_versions = fetch_pypi_versions(metadata.distribution)
+    published_stub_versions = fetch_pypi_versions(metadata.stub_distribution)
     version = compute_incremented_version(
         metadata.version_spec, published_stub_versions
     )

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -3,13 +3,17 @@ from typing import Any, Dict, List, Optional
 
 import tomli
 
-from .const import META, THIRD_PARTY_NAMESPACE
+from .const import META, THIRD_PARTY_NAMESPACE, TYPES_PREFIX
 
 
 class Metadata:
     def __init__(self, distribution: str, data: Dict[str, Any]):
-        self.distribution = distribution
+        self.upstream_distribution = distribution
         self.data = data
+
+    @property
+    def stub_distribution(self) -> str:
+        return TYPES_PREFIX + self.upstream_distribution
 
     @property
     def version_spec(self) -> str:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,9 +15,9 @@ UPLOADED = "data/uploaded_packages.txt"
 
 def test_fetch_pypi_versions() -> None:
     """Check that we can query PyPI for package increments."""
-    assert Version("1.16.0") in get_version.fetch_pypi_versions("six")
-    assert Version("1.5.4") in get_version.fetch_pypi_versions("typed-ast")
-    assert not get_version.fetch_pypi_versions("nonexistent-distribution")
+    assert Version("1.16.0") in get_version.fetch_pypi_versions("types-six")
+    assert Version("1.5.4") in get_version.fetch_pypi_versions("types-typed-ast")
+    assert not get_version.fetch_pypi_versions("types-nonexistent-distribution")
 
 
 def test_check_exists() -> None:


### PR DESCRIPTION
As we plan to allow non types- dependencies, it becomes more important to be clear about when we're referring to types- packages and when not. Automatically prefixing types- in `fetch_pypi_versions` was a little surprising to me.