### PR TITLE
Finish changing versioning scheme

### DIFF
--- a/stub_uploader/get_version.py
+++ b/stub_uploader/get_version.py
@@ -89,16 +89,12 @@ def compute_incremented_version(
     if max_published.epoch > 0 or version_base.epoch > 0:
         raise NotImplementedError("Epochs in versions are not supported")
 
-    increment_specificity = specificity + 1
-    # TODO: uncomment this in follow-up PR
     # We'll try to bump the fourth part of the release. So e.g. if our version_spec is
     # 1.1, we'll release 1.1.0.0, 1.1.0.1, 1.1.0.2, ...
     # But if our version_spec is 5.6.7.8, we'll release 5.6.7.8.0, 5.6.7.8.1, ...
-    # increment_specificity = max(specificity + 1, 4)
+    increment_specificity = max(specificity + 1, 4)
 
     if version_base.release < max_published.release[:specificity]:
-        raise AssertionError("TODO: remove this exception in follow-up PR")
-
         # Our published versions have gone too far ahead the upstream version
         # So we can't guarantee our second property.
         # In practice, this will only happen if the specificity of version_spec is

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -50,31 +50,6 @@ def _incremented_ver(ver: str, published: list[str]) -> str:
     return str(compute_incremented_version(ver, published_vers))
 
 
-def test_compute_incremented_version_legacy() -> None:
-    # never before published version
-    empty_list: list[str] = []
-    assert _incremented_ver("1", empty_list) == "1.0"
-    assert _incremented_ver("1.2", empty_list) == "1.2.0"
-
-    # published less than version spec
-    assert _incremented_ver("1.2", ["1.1.0.4"]) == "1.2.0"
-    assert _incremented_ver("1", ["0.9"]) == "1.0"
-    assert _incremented_ver("1.1", ["0.9"]) == "1.1.0"
-    assert _incremented_ver("1.2.3", ["1.1.0.17"]) == "1.2.3.0"
-    assert _incremented_ver("1.2.3.4", ["1.1.0.17"]) == "1.2.3.4.0"
-
-    # published equals version spec
-    assert _incremented_ver("1.1", ["1.1"]) == "1.1.1"
-    assert _incremented_ver("1.1", ["1.1.0.4"]) == "1.1.0.5"
-    assert _incremented_ver("1.1", ["1.1.3.4"]) == "1.1.3.5"
-    assert _incremented_ver("1.2.3.4", ["1.2.3.4.5"]) == "1.2.3.4.6"
-    assert _incremented_ver("1.2.3.4.5", ["1.2.3.4.5"]) == "1.2.3.4.5.1"
-
-    # test that we do the max version right
-    assert _incremented_ver("1.2", ["1.1.0.7", "1.2.0.7"]) == "1.2.0.8"
-
-
-@pytest.mark.skip(reason="Will use in follow-up PR")
 def test_compute_incremented_version() -> None:
     # never before published version
     empty_list: list[str] = []


### PR DESCRIPTION
This change was removed from #57, so as to make that PR more a refactoring. The changes here accomplish two things:

First, allows us to change the specificity of how we pin versions in typeshed while ensuring that users who install without pinning versions still get the latest stub.

Second, incrementing the fourth position helps disambiguate "upstream version" from "types version", reducing user confusion. See my comment
here: https://github.com/typeshed-internal/stub_uploader/pull/57#discussion_r956395229

We can wait longer if we're suspicious of #57, but there have been a half dozen stub uploads since then. Please let me know if there are any tests I could add that would be worthwhile.