### PR TITLE
CI: Use explicit Python versions to fix a warning

### DIFF
--- a/.github/workflows/check_scripts.yml
+++ b/.github/workflows/check_scripts.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - uses: actions/checkout@v3
       - run: pip install black
       - run: |
@@ -22,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - uses: actions/checkout@v3
       - run: pip install -r requirements.txt
       - run: mypy --strict -p stub_uploader -p tests
@@ -31,10 +33,10 @@ jobs:
     name: Run integration and unit tests
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Python 3.9
+      - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Checkout main
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/force_update.yml
+++ b/.github/workflows/force_update.yml
@@ -11,10 +11,10 @@ jobs:
   build-and-upload:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Python 3.9
+      - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Checkout main
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test_api_token.yml
+++ b/.github/workflows/test_api_token.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/update_stubs.yml
+++ b/.github/workflows/update_stubs.yml
@@ -11,10 +11,10 @@ jobs:
   build-and-upload:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Python 3.9
+      - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: '3.10'
       - name: Checkout main
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Update to Python 3.10