### PR TITLE
Support a "stub_distribution" metadata field

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -25,8 +25,13 @@ import tempfile
 from textwrap import dedent
 from typing import Optional
 
-from stub_uploader.const import (CHANGELOG_PATH, META, TESTS_NAMESPACE,
-                                 THIRD_PARTY_NAMESPACE, TYPES_PREFIX)
+from stub_uploader.const import (
+    CHANGELOG_PATH,
+    META,
+    TESTS_NAMESPACE,
+    THIRD_PARTY_NAMESPACE,
+    TYPES_PREFIX,
+)
 from stub_uploader.metadata import Metadata, read_metadata
 
 CHANGELOG = "CHANGELOG.md"
@@ -240,11 +245,15 @@ def generate_long_description(
             OBSOLETE_SINCE_TEXT_TEMPLATE.format(
                 distribution=distribution,
                 stub_distribution=metadata.stub_distribution,
-                obsolete_since=metadata.obsolete_since
+                obsolete_since=metadata.obsolete_since,
             )
         )
     elif metadata.no_longer_updated:
-        parts.append(NO_LONGER_UPDATED_TEMPLATE.format(stub_distribution=metadata.stub_distribution))
+        parts.append(
+            NO_LONGER_UPDATED_TEMPLATE.format(
+                stub_distribution=metadata.stub_distribution
+            )
+        )
     parts.append(DESCRIPTION_OUTRO_TEMPLATE.format(commit=commit))
     return "\n\n".join(parts)
 

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -25,12 +25,8 @@ import tempfile
 from textwrap import dedent
 from typing import Optional
 
-from stub_uploader.const import (
-    CHANGELOG_PATH,
-    META,
-    TESTS_NAMESPACE,
-    THIRD_PARTY_NAMESPACE,
-)
+from stub_uploader.const import (CHANGELOG_PATH, META, TESTS_NAMESPACE,
+                                 THIRD_PARTY_NAMESPACE, TYPES_PREFIX)
 from stub_uploader.metadata import Metadata, read_metadata
 
 CHANGELOG = "CHANGELOG.md"
@@ -41,7 +37,7 @@ SETUP_TEMPLATE = dedent(
     """
 from setuptools import setup
 
-name = "types-{distribution}"
+name = "{stub_distribution}"
 description = "Typing stubs for {distribution}"
 long_description = '''
 {long_description}
@@ -73,12 +69,12 @@ setup(name=name,
 ).lstrip()
 
 NO_LONGER_UPDATED_TEMPLATE = """
-*Note:* `types-{distribution}` is unmaintained and won't be updated.
+*Note:* `{stub_distribution}` is unmaintained and won't be updated.
 """.lstrip()
 
 OBSOLETE_SINCE_TEXT_TEMPLATE = """
 *Note:* The `{distribution}` package includes type annotations or type stubs
-since version {obsolete_since}. Please uninstall the `types-{distribution}`
+since version {obsolete_since}. Please uninstall the `{stub_distribution}`
 package if you use this or a newer version.
 """.lstrip()
 
@@ -220,6 +216,7 @@ def generate_setup_file(
     package_data = collect_setup_entries(build_data.stub_dir)
     return SETUP_TEMPLATE.format(
         distribution=build_data.distribution,
+        stub_distribution=metadata.stub_distribution,
         long_description=generate_long_description(
             build_data.distribution, commit, metadata
         ),
@@ -241,11 +238,13 @@ def generate_long_description(
     if metadata.obsolete_since:
         parts.append(
             OBSOLETE_SINCE_TEXT_TEMPLATE.format(
-                distribution=distribution, obsolete_since=metadata.obsolete_since
+                distribution=distribution,
+                stub_distribution=metadata.stub_distribution,
+                obsolete_since=metadata.obsolete_since
             )
         )
     elif metadata.no_longer_updated:
-        parts.append(NO_LONGER_UPDATED_TEMPLATE.format(distribution=distribution))
+        parts.append(NO_LONGER_UPDATED_TEMPLATE.format(stub_distribution=metadata.stub_distribution))
     parts.append(DESCRIPTION_OUTRO_TEMPLATE.format(commit=commit))
     return "\n\n".join(parts)
 

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -30,7 +30,6 @@ from stub_uploader.const import (
     META,
     TESTS_NAMESPACE,
     THIRD_PARTY_NAMESPACE,
-    TYPES_PREFIX,
 )
 from stub_uploader.metadata import Metadata, read_metadata
 

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -4,8 +4,8 @@ import functools
 import graphlib
 import os
 import re
-from typing import Any, Optional
 from collections.abc import Iterator
+from typing import Any, Optional
 
 import requests
 import tomli
@@ -34,7 +34,7 @@ class Metadata:
 
     @property
     def stub_distribution(self) -> str:
-        return TYPES_PREFIX + self._alleged_upstream_distribution
+        return self.data.get("stub_distribution", TYPES_PREFIX + self._alleged_upstream_distribution)
 
     @property
     def version_spec(self) -> str:

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -34,7 +34,9 @@ class Metadata:
 
     @property
     def stub_distribution(self) -> str:
-        return self.data.get("stub_distribution", TYPES_PREFIX + self._alleged_upstream_distribution)
+        return self.data.get(
+            "stub_distribution", TYPES_PREFIX + self._alleged_upstream_distribution
+        )
 
     @property
     def version_spec(self) -> str:


### PR DESCRIPTION
This allows us to override the generated and uploaded distribution name,
e.g. if the name is already in use.

Cf. python/typeshed#9246