### PR TITLE
Add "black" to requirements

### DIFF
--- a/.github/workflows/check_scripts.yml
+++ b/.github/workflows/check_scripts.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           python-version: '3.10'
       - uses: actions/checkout@v3
-      - run: pip install black
+      - run: pip install -r requirements.txt
       - run: |
           black --version
           black --check .

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ twine
 mypy
 pytest
 types-requests
+
+black


### PR DESCRIPTION
CI checks for black formatting, so we might as well add it to the requirements so it's available by default.