### PR TITLE
Add "stub_distribution" and "upload" metadata fields

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -4,8 +4,8 @@ import functools
 import graphlib
 import os
 import re
-from typing import Any, Optional
 from collections.abc import Iterator
+from typing import Any, Optional
 
 import requests
 import tomli
@@ -34,7 +34,9 @@ class Metadata:
 
     @property
     def stub_distribution(self) -> str:
-        return TYPES_PREFIX + self._alleged_upstream_distribution
+        return self.data.get(
+            "stub_distribution", TYPES_PREFIX + self._alleged_upstream_distribution
+        )
 
     @property
     def version_spec(self) -> str:
@@ -89,6 +91,10 @@ class Metadata:
     @property
     def no_longer_updated(self) -> bool:
         return self.data.get("no_longer_updated", False)
+
+    @property
+    def upload(self) -> bool:
+        return self.data.get("upload", True)
 
 
 def read_metadata(typeshed_dir: str, distribution: str) -> Metadata:

--- a/stub_uploader/upload.py
+++ b/stub_uploader/upload.py
@@ -39,7 +39,7 @@ def upload(
         print(f"ok, version {version}")
 
         print(f"Uploading stubs for {distribution}... ", end="")
-        if dry_run:
+        if dry_run or not metadata.upload:
             print(f"skipped")
         else:
             subprocess.run(["twine", "upload", os.path.join(temp_dir, "*")], check=True)


### PR DESCRIPTION
These optional fields allow more control over what gets uploaded from the typeshed side:

* `stub_distribution` allows to change the uploaded distribution name.
* Setting `upload` to `false` prevents uploading a package (e.g. in case of errors).