### PR TITLE
Make tests pass on Windows

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -21,6 +21,7 @@ import os
 import os.path
 import shutil
 import subprocess
+import sys
 import tempfile
 from textwrap import dedent
 from typing import Optional
@@ -285,8 +286,8 @@ def main(
     copy_changelog(distribution, tmpdir)
     current_dir = os.getcwd()
     os.chdir(tmpdir)
-    subprocess.run(["python3", "setup.py", "bdist_wheel"])
-    subprocess.run(["python3", "setup.py", "sdist"])
+    subprocess.run([sys.executable, "setup.py", "bdist_wheel"])
+    subprocess.run([sys.executable, "setup.py", "sdist"])
     os.chdir(current_dir)
     return f"{tmpdir}/dist"
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -81,9 +81,9 @@ def test_collect_setup_entries() -> None:
                 "__init__.pyi",
                 "a.pyi",
                 "b.pyi",
-                "c/__init__.pyi",
-                "c/d.pyi",
-                "c/e.pyi",
+                os.path.join("c", "__init__.pyi"),
+                os.path.join("c", "d.pyi"),
+                os.path.join("c", "e.pyi"),
                 "METADATA.toml",
             ]
         }
@@ -93,7 +93,7 @@ def test_collect_setup_entries() -> None:
     assert entries == (
         {
             "nspkg-stubs": [
-                "innerpkg/__init__.pyi",
+                os.path.join("innerpkg", "__init__.pyi"),
                 "METADATA.toml",
             ]
         }


### PR DESCRIPTION
I cloned `stub_uploader` to work on the `stub_uploader` CI failure in https://github.com/python/typeshed/pull/9459, and was somewhat surprised when *all* the tests failed for me locally :)