### PR TITLE
Non-types dependencies: whitelist `arrow`, `click`, `Flask`, `Werkzeug`

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -164,8 +164,12 @@ def verify_typeshed_req(req: Requirement) -> None:
 # Note we could loosen our criteria once we address:
 # https://github.com/typeshed-internal/stub_uploader/pull/61#discussion_r979327370
 EXTERNAL_REQ_ALLOWLIST = {
-    "numpy",
+    "Flask",
+    "Werkzeug",
+    "arrow",
+    "click",
     "cryptography",
+    "numpy",
     "torch",
 }
 


### PR DESCRIPTION
This PR adds four new items to the "non-types dependencies whitelist", in preparation for non-types dependencies being allowed in typeshed: `arrow`, `click`, `Flask`, and `Werkzeug`.

## `arrow`

Typeshed has had a PR open to add stubs for `python-datemath` for a long time now: https://github.com/python/typeshed/pull/5765. The `arrow` package is fundamental to `python-datemath`, so the PR realistically can't be merged without having `arrow` as a dependency. At runtime, `arrow` only depends on `python-dateutils` and, on Python <3.8, `typing_extensions`: https://github.com/arrow-py/arrow/blob/74a759b88447b6ecd9fd5de610f272c8fb6130a2/setup.py#L25-L28. It is actively maintained, and has 8.2k stars on GitHub. `arrow` is the sole dependency of `python-datemath` at runtime: https://github.com/nickmaccarthy/python-datemath/blob/6d047b3cc4e357d83b50e7433c812994e21c3ffb/setup.py#L86.

## `click`

Typeshed has a PR open to add stubs for the `click-default-group`: https://github.com/python/typeshed/pull/9304. Similar to the PR adding stubs for `python-datemath`, there's not much point merging the PR unless it can declare a dependency on `click`; `click` is just too fundamental to the package. `click` is obviously a hugely popular CLI framework for Python. Its only dependencies at runtime are `colorama` (if you're on Windows) and `importlib-metadata` (if you're on Python <3.8): https://github.com/pallets/click/blob/9595a190d79e80945f6827a79f12937a8212f307/setup.py#L5-L8. `click` is the sole dependency of `click-default-group` at runtime: https://github.com/click-contrib/click-default-group/blob/b671ae5325d186fe5ea7abb584f15852a1e931aa/setup.py#L52.

## `Flask` and `Werkzeug`

Typeshed has stubs for several `Flask` plugins. Being able to declare a dependency on `Flask` would be useful for typeshed's stubs for [`Flask-Cors`](https://github.com/python/typeshed/blob/41de5317b5008719c899b0ca61f9fd37b774cade/stubs/Flask-Cors/flask_cors/core.pyi#L10) and [`Flask-Migrate`](https://github.com/python/typeshed/blob/41de5317b5008719c899b0ca61f9fd37b774cade/stubs/Flask-Migrate/flask_migrate/__init__.pyi#L10) in particular. `Flask` is declared as a dependency of both [`Flask-Cors`](https://github.com/corydolphin/flask-cors/blob/cad70b3298fdd5605e1c09628050e2598f6f7e0e/requirements.txt#L1) and [`Flask-Migrate`](https://github.com/miguelgrinberg/Flask-Migrate/blob/a7714530453d6cc1b882944ec4f3002b6745e9c5/setup.cfg#L28) at runtime. `Flask` is obviously a hugely popular web framework for Python, that is actively maintained. It has a few more dependencies at runtime than the others on this list, but still not very many: https://github.com/pallets/flask/blob/836866dc19218832cf02f8b04911060ac92bfc0b/setup.py#L6-L12.

Typeshed's stubs for `Flask-Cors` would also benefit from being able to declare a dependency on `Werkzeug`: https://github.com/python/typeshed/blob/41de5317b5008719c899b0ca61f9fd37b774cade/stubs/Flask-Cors/flask_cors/core.pyi#L12. The benefit to this one would be fairly small, but it also seems silly to _disallow_ declaring a dependency on `Werkzeug`, since `Werkzeug` is already a dependency of `Flask` at runtime, and is just as actively maintained as `Flask`.