### PR TITLE
Add `Flask-SQLAlchemy` to the allowlist

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -165,6 +165,7 @@ def verify_typeshed_req(req: Requirement) -> None:
 # https://github.com/typeshed-internal/stub_uploader/pull/61#discussion_r979327370
 EXTERNAL_REQ_ALLOWLIST = {
     "Flask",
+    "Flask-SQLAlchemy",
     "Werkzeug",
     "arrow",
     "click",


### PR DESCRIPTION
Needed for https://github.com/python/typeshed/pull/9989. There are other blockers on that PR at the moment, but we will *eventually* want to have our stubs for `Flask-Migrate` declare a dependency on `Flask-SQLAlchemy`, even if we have to wait a little bit before we're able to do that.