### PR TITLE
Allow marking stubs as partial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 stubtest-output*
+mypy-*
 
 # Translations
 *.mo

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -273,11 +273,7 @@ def generate_long_description(
             )
         )
     elif metadata.partial:
-        parts.append(
-            NO_LONGER_UPDATED_TEMPLATE.format(
-                stub_distribution=metadata.stub_distribution
-            )
-        )
+        parts.append(PARTIAL_STUBS_DESCRIPTION)
     parts.append(DESCRIPTION_OUTRO_TEMPLATE.format(commit=commit))
     return "\n\n".join(parts)
 

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -38,6 +38,11 @@ CHANGELOG = "CHANGELOG.md"
 
 SUFFIX = "-stubs"
 
+PARTIAL_STUBS_DESCRIPTION = """
+This stub package is marked as [partial](https://peps.python.org/pep-0561/#partial-stub-packages).
+If you find that annotations are missing, feel free to contribute and help complete them.
+""".lstrip()
+
 SETUP_TEMPLATE = dedent(
     """
 from setuptools import setup
@@ -110,7 +115,7 @@ def find_stub_files(top: str) -> list[str]:
 
     Raise if we find any unknown file extensions during collection.
     """
-    result = []
+    result: list[str] = []
     for root, _, files in os.walk(top):
         for file in files:
             if file.endswith(".pyi"):
@@ -140,7 +145,8 @@ def copy_stubs(base_dir: str, dst: str) -> None:
             if not entry.endswith(".pyi"):
                 continue
             stub_dir = os.path.join(dst, entry.split(".")[0] + SUFFIX)
-            os.mkdir(stub_dir)
+            if not os.path.exists(stub_dir):
+                os.mkdir(stub_dir)
             shutil.copy(
                 os.path.join(base_dir, entry), os.path.join(stub_dir, "__init__.pyi")
             )
@@ -180,7 +186,7 @@ def collect_setup_entries(base_dir: str) -> dict[str, list[str]]:
 
     This reflects the transformations done during copying in copy_stubs().
     """
-    package_data = {}
+    package_data: dict[str, list[str]] = {}
     for entry in os.listdir(base_dir):
         if entry == META:
             # Metadata file entry is added at the end.
@@ -211,6 +217,16 @@ def collect_setup_entries(base_dir: str) -> dict[str, list[str]]:
     return package_data
 
 
+def add_partial_marker(package_data: dict[str, list[str]], stub_dir: str):
+    for entry, files in package_data.items():
+        entry_path = os.path.join(stub_dir, entry)
+        if not os.path.exists(entry_path):
+            os.mkdir(entry_path)
+        with open(os.path.join(entry_path, "py.typed"), "w") as py_typed:
+            py_typed.write("partial\n")
+        files.append("py.typed")
+
+
 def generate_setup_file(
     build_data: BuildData, metadata: Metadata, version: str, commit: str
 ) -> str:
@@ -219,6 +235,8 @@ def generate_setup_file(
         str(req) for req in metadata.requires_typeshed + metadata.requires_external
     ]
     package_data = collect_setup_entries(build_data.stub_dir)
+    if metadata.partial:
+        add_partial_marker(package_data, build_data.stub_dir)
     return SETUP_TEMPLATE.format(
         distribution=build_data.distribution,
         stub_distribution=metadata.stub_distribution,
@@ -236,7 +254,7 @@ def generate_long_description(
     distribution: str, commit: str, metadata: Metadata
 ) -> str:
     extra_description = metadata.extra_description.strip()
-    parts = []
+    parts: list[str] = []
     parts.append(DESCRIPTION_INTRO_TEMPLATE.format(distribution=distribution))
     if extra_description:
         parts.append(extra_description)
@@ -249,6 +267,12 @@ def generate_long_description(
             )
         )
     elif metadata.no_longer_updated:
+        parts.append(
+            NO_LONGER_UPDATED_TEMPLATE.format(
+                stub_distribution=metadata.stub_distribution
+            )
+        )
+    elif metadata.partial:
         parts.append(
             NO_LONGER_UPDATED_TEMPLATE.format(
                 stub_distribution=metadata.stub_distribution

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -145,8 +145,7 @@ def copy_stubs(base_dir: str, dst: str) -> None:
             if not entry.endswith(".pyi"):
                 continue
             stub_dir = os.path.join(dst, entry.split(".")[0] + SUFFIX)
-            if not os.path.exists(stub_dir):
-                os.mkdir(stub_dir)
+            os.makedirs(stub_dir, exist_ok=True)
             shutil.copy(
                 os.path.join(base_dir, entry), os.path.join(stub_dir, "__init__.pyi")
             )
@@ -220,8 +219,7 @@ def collect_setup_entries(base_dir: str) -> dict[str, list[str]]:
 def add_partial_marker(package_data: dict[str, list[str]], stub_dir: str) -> None:
     for entry, files in package_data.items():
         entry_path = os.path.join(stub_dir, entry)
-        if not os.path.exists(entry_path):
-            os.mkdir(entry_path)
+        os.makedirs(entry_path, exist_ok=True)
         with open(os.path.join(entry_path, "py.typed"), "w") as py_typed:
             py_typed.write("partial\n")
         files.append("py.typed")
@@ -272,7 +270,7 @@ def generate_long_description(
                 stub_distribution=metadata.stub_distribution
             )
         )
-    elif metadata.partial:
+    if metadata.partial:
         parts.append(PARTIAL_STUBS_DESCRIPTION)
     parts.append(DESCRIPTION_OUTRO_TEMPLATE.format(commit=commit))
     return "\n\n".join(parts)

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -217,7 +217,7 @@ def collect_setup_entries(base_dir: str) -> dict[str, list[str]]:
     return package_data
 
 
-def add_partial_marker(package_data: dict[str, list[str]], stub_dir: str):
+def add_partial_marker(package_data: dict[str, list[str]], stub_dir: str) -> None:
     for entry, files in package_data.items():
         entry_path = os.path.join(stub_dir, entry)
         if not os.path.exists(entry_path):

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -96,6 +96,10 @@ class Metadata:
     def upload(self) -> bool:
         return self.data.get("upload", True)
 
+    @property
+    def partial(self) -> bool:
+        return self.data.get("ignore_missing_stub", False)
+
 
 def read_metadata(typeshed_dir: str, distribution: str) -> Metadata:
     """Parse metadata from file."""

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -98,7 +98,7 @@ class Metadata:
 
     @property
     def partial(self) -> bool:
-        return self.data.get("ignore_missing_stub", False)
+        return self.data.get("partial_stub", False)
 
 
 def read_metadata(typeshed_dir: str, distribution: str) -> Metadata:


### PR DESCRIPTION
Closes #93

I'm sure this can be improved. Also please review and test carefully (I'm still running integration tests, but they're taking forever).

~~The basic idea is to infer a stub package being `partial` from finding `ignore_missing_stub = true` in the metadata. If we decide to add a specific "partial" entry in the metadata, the logic will stay the same, only the property's inner code will change.~~
Edit: went for a separate metadata key.

Alternatively typeshed could add the `partial\n` `py.typed` marker itself (assuming it can use packages instead of single files for single-file source w/o problem with stubtest)