### PR TITLE
Pin requests to <2.30.0 to fix test failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 packaging
-requests
+requests<2.30.0
 tomli
 
 setuptools


### PR DESCRIPTION
`requests v2.30.0` has just been released: https://github.com/psf/requests/releases/tag/v2.30.0

It appears to be causing the stub-uploader tests to fail on the typeshed `main` branch:
  - https://github.com/python/typeshed/actions/runs/4873926053/jobs/8694191409
  - https://github.com/python/typeshed/actions/runs/4873908728/jobs/8694149563

I haven't looked into what's causing the failures at all, but here's a stopgap PR to pin `requests` and stop the tests from failing