### PR TITLE
Add MarkupSafe to the external requirements allow list

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -174,6 +174,7 @@ def verify_typeshed_req(req: Requirement) -> None:
 EXTERNAL_REQ_ALLOWLIST = {
     "Flask",
     "Flask-SQLAlchemy",
+    "MarkupSafe",
     "Werkzeug",
     "arrow",
     "click",


### PR DESCRIPTION
This is necessary for types-WTForms, open PR for that is here: https://github.com/python/typeshed/pull/10557