### PR TITLE
Add referencing to required allowlist

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -180,6 +180,7 @@ EXTERNAL_REQ_ALLOWLIST = {
     "click",
     "cryptography",
     "numpy",
+    "referencing",
     "torch",
     "urllib3",
 }


### PR DESCRIPTION
Required by jsonschema. Referencing is currently 133th place in the PyPI downloads: https://hugovk.github.io/top-pypi-packages/