### PR TITLE
Support .postN versions

### DIFF
--- a/stub_uploader/get_version.py
+++ b/stub_uploader/get_version.py
@@ -58,7 +58,7 @@ def compute_incremented_version(
     # need revisiting.
     max_published = max(published_versions, default=Version("0"))
 
-    # Parse and massage the base version. if necessary. Usually, the base version is
+    # Parse and massage the base version if necessary. Usually, the base version is
     # just the version_spec without any trailing `.*`. But if the version_spec is a
     # post version, we append the post version to the base version:
     #   1.2.post3 -> 1.2.3

--- a/stub_uploader/get_version.py
+++ b/stub_uploader/get_version.py
@@ -52,6 +52,7 @@ def ensure_specificity(ver: list[int], specificity: int) -> None:
 
 POST_SPEC_RE = re.compile(r"^(.*)\.post(\d+)$")
 
+
 def compute_incremented_version(
     version_spec: str, published_versions: list[Version]
 ) -> Version:

--- a/stub_uploader/get_version.py
+++ b/stub_uploader/get_version.py
@@ -11,8 +11,8 @@ distribution information.
 """
 
 from __future__ import annotations
-import re
 
+import re
 from typing import Any
 
 import requests

--- a/stub_uploader/get_version.py
+++ b/stub_uploader/get_version.py
@@ -86,7 +86,6 @@ def compute_incremented_version(
     if version_base.post is not None:
         version_base = Version(f"{version_base.base_version}.{version_base.post}")
 
-    # Look up the base version and specificity in METADATA.toml.
     specificity = len(version_base.release)
 
     if max_published.epoch > 0 or version_base.epoch > 0:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -43,6 +43,7 @@ def test_compute_incremented_version() -> None:
     empty_list: list[str] = []
     assert _incremented_ver("1", empty_list) == "1.0.0.0"
     assert _incremented_ver("1.2", empty_list) == "1.2.0.0"
+    assert _incremented_ver("1.2.post3", empty_list) == "1.2.3.0"
 
     # published greater than version spec
     assert _incremented_ver("1.2", ["1.3.0.4"]) == "1.3.0.5"
@@ -52,6 +53,7 @@ def test_compute_incremented_version() -> None:
     assert _incremented_ver("1.1", ["1.2.3.4.5"]) == "1.2.3.4.6"
     assert _incremented_ver("1.4.40", ["1.4.50"]) == "1.4.50.1"
     assert _incremented_ver("1.4.0.40", ["1.4.0.50"]) == "1.4.0.50.1"
+    assert _incremented_ver("1.2.post3", ["1.2.3.4"]) == "1.2.3.5"
 
     # published less than version spec
     assert _incremented_ver("1.2", ["1.1.0.4"]) == "1.2.0.0"
@@ -59,6 +61,7 @@ def test_compute_incremented_version() -> None:
     assert _incremented_ver("1.1", ["0.9"]) == "1.1.0.0"
     assert _incremented_ver("1.2.3", ["1.1.0.17"]) == "1.2.3.0"
     assert _incremented_ver("1.2.3.4", ["1.1.0.17"]) == "1.2.3.4.0"
+    assert _incremented_ver("1.2.post3", ["1.1.0.17"]) == "1.2.3.0"
 
     # published equals version spec
     assert _incremented_ver("1.1", ["1.1"]) == "1.1.0.1"


### PR DESCRIPTION
The post version is just replaced with a regular release segment, as PEP 440 doesn't support structured post versions.