### PR TITLE
Add a "requires-python" metadata field in stub distributions

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -75,6 +75,7 @@ setup(name=name,
       packages={packages},
       package_data={package_data},
       license="Apache-2.0 license",
+      python_requires="{requires_python}",
       classifiers=[
           "License :: OSI Approved :: Apache Software License",
           "Programming Language :: Python :: 3",
@@ -251,6 +252,11 @@ def generate_setup_file(
     package_data = collect_setup_entries(build_data.stub_dir)
     if metadata.partial:
         add_partial_marker(package_data, build_data.stub_dir)
+    requires_python = (
+        metadata.requires_python
+        if metadata.requires_python is not None
+        else f">={ts_data.oldest_supported_python}"
+    )
     return SETUP_TEMPLATE.format(
         distribution=build_data.distribution,
         stub_distribution=metadata.stub_distribution,
@@ -261,6 +267,7 @@ def generate_setup_file(
         requires=all_requirements,
         packages=list(package_data.keys()),
         package_data=package_data,
+        requires_python=requires_python,
     )
 
 

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -109,6 +109,7 @@ class Metadata:
     def requires_python(self) -> str | None:
         req = self.data.get("requires_python", None)
         verify_requires_python(req)
+        assert type(req) in (str, type(None))
         return req
 
 
@@ -347,12 +348,17 @@ def recursive_verify(metadata: Metadata, typeshed_dir: str) -> set[str]:
     _verify(metadata)
     return _verified
 
+
 def verify_requires_python(requires_python: str | None) -> None:
     if requires_python is None:
         return
     try:
         specifier = Specifier(requires_python)
     except InvalidSpecifier as e:
-        raise InvalidRequires(f"Invalid requires_python specifier: {requires_python}") from e
+        raise InvalidRequires(
+            f"Invalid requires_python specifier: {requires_python}"
+        ) from e
     if specifier.operator != ">=":
-        raise InvalidRequires(f"Expected requires_python to be a '>=' specifier: {requires_python}")
+        raise InvalidRequires(
+            f"Expected requires_python to be a '>=' specifier: {requires_python}"
+        )

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -108,8 +108,8 @@ class Metadata:
     @property
     def requires_python(self) -> str | None:
         req = self.data.get("requires_python", None)
-        verify_requires_python(req)
         assert isinstance(req, (str, type(None)))
+        verify_requires_python(req)
         return req
 
 

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -14,6 +14,7 @@ from typing import Any, Optional
 import requests
 import tomli
 from packaging.requirements import Requirement
+from packaging.specifiers import Specifier, InvalidSpecifier
 
 from .const import META, THIRD_PARTY_NAMESPACE, TYPES_PREFIX, UPLOADED_PATH
 
@@ -103,6 +104,12 @@ class Metadata:
     @property
     def partial(self) -> bool:
         return self.data.get("partial_stub", False)
+
+    @property
+    def requires_python(self) -> str | None:
+        req = self.data.get("requires_python", None)
+        verify_requires_python(req)
+        return req
 
 
 def read_metadata(typeshed_dir: str, distribution: str) -> Metadata:
@@ -339,3 +346,13 @@ def recursive_verify(metadata: Metadata, typeshed_dir: str) -> set[str]:
 
     _verify(metadata)
     return _verified
+
+def verify_requires_python(requires_python: str | None) -> None:
+    if requires_python is None:
+        return
+    try:
+        specifier = Specifier(requires_python)
+    except InvalidSpecifier as e:
+        raise InvalidRequires(f"Invalid requires_python specifier: {requires_python}") from e
+    if specifier.operator != ">=":
+        raise InvalidRequires(f"Expected requires_python to be a '>=' specifier: {requires_python}")

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -109,7 +109,7 @@ class Metadata:
     def requires_python(self) -> str | None:
         req = self.data.get("requires_python", None)
         verify_requires_python(req)
-        assert type(req) in (str, type(None))
+        assert isinstance(req, (str, type(None)))
         return req
 
 

--- a/stub_uploader/ts_data.py
+++ b/stub_uploader/ts_data.py
@@ -20,6 +20,7 @@ class TypeshedData:
     mypy_version: str
     pyright_version: str
     pytype_version: str
+    oldest_supported_python: str
 
 
 def read_typeshed_data(typeshed_dir: Path) -> TypeshedData:
@@ -27,10 +28,12 @@ def read_typeshed_data(typeshed_dir: Path) -> TypeshedData:
         pyproject = toml_load(f)
     with (typeshed_dir / REQUIREMENTS).open() as f:
         requirements = parse_requirements(f)
+    typeshed_table = pyproject["tool"]["typeshed"]
     return TypeshedData(
         mypy_version=requirements["mypy"],
-        pyright_version=pyproject["tool"]["typeshed"]["pyright_version"],
+        pyright_version=typeshed_table["pyright_version"],
         pytype_version=requirements["pytype"],
+        oldest_supported_python=typeshed_table["oldest_supported_python"],
     )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -158,11 +158,14 @@ def test_read_typeshed_data() -> None:
     assert re.match(r"^\d+\.\d+\.\d+$", ts_data.pytype_version)
     assert re.match(r"^\d+\.\d+$", ts_data.oldest_supported_python)
 
+
 def test_verify_requires_python() -> None:
     verify_requires_python(">=3.10")
 
     with pytest.raises(InvalidRequires, match="Invalid requires_python specifier"):
         verify_requires_python(">=fake")
 
-    with pytest.raises(InvalidRequires, match="Expected requires_python to be a '>=' specifier"):
+    with pytest.raises(
+        InvalidRequires, match="Expected requires_python to be a '>=' specifier"
+    ):
         verify_requires_python("==3.10")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,6 +21,7 @@ from stub_uploader.metadata import (
     sort_by_dependency,
     strip_types_prefix,
     verify_external_req,
+    verify_requires_python,
     verify_typeshed_req,
 )
 from stub_uploader.ts_data import read_typeshed_data
@@ -155,3 +156,13 @@ def test_read_typeshed_data() -> None:
     assert re.match(r"^\d+\.\d+\.\d+$", ts_data.mypy_version)
     assert re.match(r"^\d+\.\d+\.\d+$", ts_data.pyright_version)
     assert re.match(r"^\d+\.\d+\.\d+$", ts_data.pytype_version)
+    assert re.match(r"^\d+\.\d+$", ts_data.oldest_supported_python)
+
+def test_verify_requires_python() -> None:
+    verify_requires_python(">=3.10")
+
+    with pytest.raises(InvalidRequires, match="Invalid requires_python specifier"):
+        verify_requires_python(">=fake")
+
+    with pytest.raises(InvalidRequires, match="Expected requires_python to be a '>=' specifier"):
+        verify_requires_python("==3.10")


### PR DESCRIPTION
This is part of the work towards https://github.com/python/typeshed/issues/10722

Note that the field is called `python_requires` in `setup.py`.

References:
- typeshed issue: https://github.com/python/typeshed/issues/10722
- typeshed PR: https://github.com/python/typeshed/pull/10724
- setuptools docs: https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#python-requirement