### PR TITLE
Improve PyPI READMEs for stubs packages

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -266,10 +266,7 @@ def generate_setup_file(
         distribution=build_data.distribution,
         stub_distribution=metadata.stub_distribution,
         long_description=generate_long_description(
-            build_data.distribution,
-            commit,
-            ts_data,
-            metadata,
+            build_data.distribution, commit, ts_data, metadata
         ),
         version=version,
         requires=all_requirements,
@@ -280,10 +277,7 @@ def generate_setup_file(
 
 
 def generate_long_description(
-    distribution: str,
-    commit: str,
-    ts_data: TypeshedData,
-    metadata: Metadata,
+    distribution: str, commit: str, ts_data: TypeshedData, metadata: Metadata
 ) -> str:
     extra_description = metadata.extra_description.strip()
     parts: list[str] = []

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -108,7 +108,7 @@ PyCharm, etc. to check code that uses
 `{distribution}`.
 
 This version of `{stub_distribution}` aims to provide accurate annotations
-for `{distribution_range_supported}`.
+for `{distribution}=={typeshed_version_pin}`.
 The source for this package can be found at
 https://github.com/python/typeshed/tree/main/stubs/{distribution}. All fixes for
 types and metadata should be contributed there.
@@ -270,7 +270,6 @@ def generate_setup_file(
             commit,
             ts_data,
             metadata,
-            version,
         ),
         version=version,
         requires=all_requirements,
@@ -285,7 +284,6 @@ def generate_long_description(
     commit: str,
     ts_data: TypeshedData,
     metadata: Metadata,
-    version: str,
 ) -> str:
     extra_description = metadata.extra_description.strip()
     parts: list[str] = []
@@ -295,16 +293,12 @@ def generate_long_description(
     else:
         formatted_distribution = f"`{distribution}`"
 
-    distribution_range_supported = (
-        f"{distribution}>={'.'.join(version.split('.')[:-1])}"
-    )
-
     parts.append(
         DESCRIPTION_INTRO_TEMPLATE.format(
             distribution=distribution,
             formatted_distribution=formatted_distribution,
             stub_distribution=metadata.stub_distribution,
-            distribution_range_supported=distribution_range_supported,
+            typeshed_version_pin=metadata.version_spec,
         )
     )
     if extra_description:

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -98,13 +98,18 @@ package if you use this or a newer version.
 DESCRIPTION_INTRO_TEMPLATE = """
 ## Typing stubs for {distribution}
 
-This is a PEP 561 type stub package for the `{distribution}` package. It
-can be used by type-checking tools like
+This is a [PEP 561](https://peps.python.org/pep-0561/)
+type stub package for the {formatted_distribution} package.
+It can be used by type-checking tools like
 [mypy](https://github.com/python/mypy/),
 [pyright](https://github.com/microsoft/pyright),
 [pytype](https://github.com/google/pytype/),
 PyCharm, etc. to check code that uses
-`{distribution}`. The source for this package can be found at
+`{distribution}`.
+
+This version of `{stub_distribution}` aims to provide accurate annotations
+for `{distribution_range_supported}`.
+The source for this package can be found at
 https://github.com/python/typeshed/tree/main/stubs/{distribution}. All fixes for
 types and metadata should be contributed there.
 """.strip()
@@ -261,7 +266,11 @@ def generate_setup_file(
         distribution=build_data.distribution,
         stub_distribution=metadata.stub_distribution,
         long_description=generate_long_description(
-            build_data.distribution, commit, ts_data, metadata
+            build_data.distribution,
+            commit,
+            ts_data,
+            metadata,
+            version,
         ),
         version=version,
         requires=all_requirements,
@@ -272,11 +281,32 @@ def generate_setup_file(
 
 
 def generate_long_description(
-    distribution: str, commit: str, ts_data: TypeshedData, metadata: Metadata
+    distribution: str,
+    commit: str,
+    ts_data: TypeshedData,
+    metadata: Metadata,
+    version: str,
 ) -> str:
     extra_description = metadata.extra_description.strip()
     parts: list[str] = []
-    parts.append(DESCRIPTION_INTRO_TEMPLATE.format(distribution=distribution))
+
+    if metadata.upstream_repository is not None:
+        formatted_distribution = f"[`{distribution}`]({metadata.upstream_repository})"
+    else:
+        formatted_distribution = f"`{distribution}`"
+
+    distribution_range_supported = (
+        f"{distribution}>={'.'.join(version.split('.')[:-1])}"
+    )
+
+    parts.append(
+        DESCRIPTION_INTRO_TEMPLATE.format(
+            distribution=distribution,
+            formatted_distribution=formatted_distribution,
+            stub_distribution=metadata.stub_distribution,
+            distribution_range_supported=distribution_range_supported,
+        )
+    )
     if extra_description:
         parts.append(extra_description)
     if metadata.obsolete_since:

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -112,6 +112,10 @@ class Metadata:
         verify_requires_python(req)
         return req
 
+    @property
+    def upstream_repository(self) -> str | None:
+        return self.data.get("upstream_repository")
+
 
 def read_metadata(typeshed_dir: str, distribution: str) -> Metadata:
     """Parse metadata from file."""

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -5,6 +5,7 @@ import graphlib
 import os
 import re
 import tarfile
+import urllib.parse
 from collections.abc import Generator, Iterable
 from glob import glob
 from pathlib import Path
@@ -112,9 +113,20 @@ class Metadata:
         verify_requires_python(req)
         return req
 
-    @property
+    @functools.cached_property
     def upstream_repository(self) -> str | None:
-        return self.data.get("upstream_repository")
+        ts_upstream_repo = self.data.get("upstream_repository")
+        if not isinstance(ts_upstream_repo, str):
+            # either typeshed doesn't list it for these stubs,
+            # or it gives a non-str for the field (bad!)
+            return None
+        try:
+            parsed_url = urllib.parse.urlsplit(ts_upstream_repo)
+        except ValueError:
+            return None
+        if parsed_url.scheme != "https":
+            return None
+        return ts_upstream_repo
 
 
 def read_metadata(typeshed_dir: str, distribution: str) -> Metadata:


### PR DESCRIPTION
- Link directly to PEP-561
- Link directly to the runtime package the stubs are for, if typeshed provides the `upstream_repository` field in a stubs package's `METADATA.toml` file.
- Clearly state that `types-requests==2.31.0.8` aims to provide accurate annotations for `requests>=2.31.0`.