### PR TITLE
Upload only once per day

### DIFF
--- a/.github/workflows/update_stubs.yml
+++ b/.github/workflows/update_stubs.yml
@@ -1,9 +1,9 @@
 name: Periodic update of stubs from typeshed to PyPI
 
 on:
-  # Triggers the workflow every three hours starting midnight UTC.
+  # Triggers the workflow each day at 02:00 UTC.
   schedule:
-    - cron: 0 */3 * * *
+    - cron: 0 2 * * *
   # If needed, allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
This is a preparation for python/typeshed#10837, where we switch to date-based versioning system for the uploaded stubs.