### PR TITLE
Add django-stubs, djangorestframework-stubs to allowlist

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -221,6 +221,8 @@ EXTERNAL_REQ_ALLOWLIST = {
     "referencing",
     "torch",
     "urllib3",
+    "django-stubs",
+    "djangorestframework-stubs",
 }
 
 

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -215,14 +215,14 @@ EXTERNAL_REQ_ALLOWLIST = {
     "arrow",
     "click",
     "cryptography",
+    "django-stubs",
+    "djangorestframework-stubs",
     "matplotlib",
     "numpy",
     "pandas-stubs",
     "referencing",
     "torch",
     "urllib3",
-    "django-stubs",
-    "djangorestframework-stubs",
 }
 
 


### PR DESCRIPTION
Prerequisite for https://github.com/python/typeshed/pull/10919

* https://github.com/python/typeshed/pull/10919

Neither package appears in the [PyPI top 1000 list](https://hugovk.github.io/top-pypi-packages/). django-stubs is nr 1686 and djangorestframework-stubs is nr 2039.

But @sobolevn can vouch for the fact that these dependencies aren't evil :smiling_imp: