### PR TITLE
Run tests using Python 3.12 in CI

### DIFF
--- a/.github/workflows/check_scripts.yml
+++ b/.github/workflows/check_scripts.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - uses: actions/checkout@v4
       - run: pip install -r requirements.txt
       - run: |
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - uses: actions/checkout@v4
       - run: pip install -r requirements.txt
       - run: mypy --strict -p stub_uploader -p tests
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Checkout main
         uses: actions/checkout@v4
         with:
@@ -50,4 +50,4 @@ jobs:
         run: |
           cd main
           pip install -r requirements.txt
-          python -m pytest tests
+          python -Werror -m pytest tests

--- a/.github/workflows/check_scripts.yml
+++ b/.github/workflows/check_scripts.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   black:
     name: Check formatting with black

--- a/.github/workflows/force_update.yml
+++ b/.github/workflows/force_update.yml
@@ -7,6 +7,9 @@ on:
         description: 'Package name or pattern (Python regexp)'
         required: true
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_api_token.yml
+++ b/.github/workflows/test_api_token.yml
@@ -9,6 +9,9 @@ on:
         required: true
         default: 0
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_api_token.yml
+++ b/.github/workflows/test_api_token.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/update_stubs.yml
+++ b/.github/workflows/update_stubs.yml
@@ -7,6 +7,9 @@ on:
   # If needed, allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -244,6 +244,8 @@ def extract_sdist_requires(
         file.write(resp.raw.read())
 
     with tarfile.open(archive_path) as file_in:
+        if hasattr(tarfile, "data_filter"):
+            file_in.extraction_filter = tarfile.data_filter
         file_in.extractall(tmpdir)
 
     # Only a single folder with "<package-version>.egg-info/requires.txt" in the archive should exist


### PR DESCRIPTION
And fix a tarfile DeprecationWarning that's new in Python 3.12, and has been showing up when the `stub_uploader` tests are run in typeshed's CI.

The tarfile extraction filters were backported to all security branches as part of PEP 706. Nonetheless, I used the method the docs advise to ensure backwards compatibility with versions of Python that don't have these extraction filters (e.g. if you're running with Python 3.11.4, the feature exists, but if you're running with Python 3.11.3, it doesn't). See https://docs.python.org/3.12/library/tarfile.html#supporting-older-python-versions.
