### PR TITLE
Don't try to upload stubs if it's a fork

### DIFF
--- a/.github/workflows/update_stubs.yml
+++ b/.github/workflows/update_stubs.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'typeshed-internal/stub_uploader' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
For some reason this job has started failing on a daily basis on my fork recently: https://github.com/AlexWaygood/stub_uploader/actions/runs/8777568621/job/24082697261

I'm not sure why this only started failing *recently*, but the job probably shouldn't be running on forks at all