### PR TITLE
Use a link in outro comment

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -115,7 +115,8 @@ types and metadata should be contributed there.
 
 DESCRIPTION_OUTRO_TEMPLATE = """
 See https://github.com/python/typeshed/blob/main/README.md for more details.
-This package was generated from typeshed commit `{commit}` and was tested
+This package was generated from typeshed commit
+[`{commit}`](https://github.com/python/typeshed/commit/{commit}) and was tested
 with mypy {ts_data.mypy_version}, pyright {ts_data.pyright_version}, and
 pytype {ts_data.pytype_version}.
 """.strip()


### PR DESCRIPTION
This is how it currently looks like:
<img width="793" alt="Снимок экрана 2024-07-10 в 13 54 13" src="https://github.com/typeshed-internal/stub_uploader/assets/4660275/40e92adf-87f3-4f79-bbfe-65f06ab69ba2">

When I wanted to click on that commit I realized that I have to:
- Go to `typeshed`
- Select some other commit page
- Copy-paste the needed commit from the outro

It would be better with a link :)