### PR TITLE
Add setuptools to EXTERNAL_REQ_ALLOWLIST

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -222,6 +222,7 @@ EXTERNAL_REQ_ALLOWLIST = {
     "numpy",
     "pandas-stubs",
     "referencing",
+    "setuptools",
     "torch",
     "tree-sitter",
     "urllib3",


### PR DESCRIPTION
This is planning for `pkg_resources`'s removal (see https://github.com/python/typeshed/issues/12398 ). And even longer term, removing `types-setuptools` entirely.
The `pygments` stub could already switch to `requires = ["setuptools>=71.1"]` as it only references `pkg_resources`