### PR TITLE
Use SPDX license string for stubs packages

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -73,7 +73,7 @@ setup(name=name,
       install_requires={requires},
       packages={packages},
       package_data={package_data},
-      license="Apache-2.0 license",
+      license="Apache-2.0",
       python_requires="{requires_python}",
       classifiers=[
           "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
The SPDX identifier for the [Apache License 2.0](https://spdx.org/licenses/Apache-2.0.html) is `Apache-2.0`. [PEP-639](https://peps.python.org/pep-0639/) is close to being finalized and it will standardize SPDX license expressions for packages. It's possible though to start using them today.

It might make sense to force update all stub packages in this case.