### PR TITLE
Validate the versions in pyproject.toml

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -155,9 +155,6 @@ def test_recursive_verify(distribution: str) -> None:
 
 def test_read_typeshed_data() -> None:
     ts_data = read_typeshed_data(Path(TYPESHED))
-    assert re.match(r"^\d+\.\d+\.\d+$", ts_data.mypy_version)
-    assert re.match(r"^\d+\.\d+\.\d+$", ts_data.pyright_version)
-    assert re.match(r"^\d+\.\d+\.\d+$", ts_data.pytype_version)
     assert re.match(r"^\d+\.\d+$", ts_data.oldest_supported_python)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,6 @@ a typeshed checkout side by side.
 
 import os
 from pathlib import Path
-import re
 
 import pytest
 from packaging.requirements import Requirement
@@ -154,8 +153,7 @@ def test_recursive_verify(distribution: str) -> None:
 
 
 def test_read_typeshed_data() -> None:
-    ts_data = read_typeshed_data(Path(TYPESHED))
-    assert re.match(r"^\d+\.\d+$", ts_data.oldest_supported_python)
+    read_typeshed_data(Path(TYPESHED))
 
 
 def test_verify_requires_python() -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -210,8 +210,9 @@ def _build_requirements(
     *,
     mypy: str | None = "1.11.1",
     pyright: str | None = "1.1.381",
-    pytype: str
-    | None = '2024.9.13; platform_system != "Windows" and python_version < "3.13"',
+    pytype: (
+        str | None
+    ) = '2024.9.13; platform_system != "Windows" and python_version < "3.13"',
 ) -> str:
     req = _REQUIREMENTS_TXT
     if mypy is not None:


### PR DESCRIPTION
Use packaging.Version instead of a regexp to validate these are valid Python versions.