### PR TITLE
Add backports.zoneinfo to allowed dependencies

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -214,6 +214,7 @@ EXTERNAL_REQ_ALLOWLIST = {
     "Pillow",
     "Werkzeug",
     "arrow",
+    "backports.zoneinfo",
     "click",
     "cryptography",
     "django-stubs",
@@ -289,7 +290,7 @@ def verify_external_req(
 
     if req.name not in EXTERNAL_REQ_ALLOWLIST and not _unsafe_ignore_allowlist:
         raise InvalidRequires(
-            f"Expected dependency {req} to be present in the allowlist"
+            f"Expected dependency {req.name} to be present in the allowlist"
         )
 
     resp = requests.get(f"https://pypi.org/pypi/{upstream_distribution}/json")

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -290,7 +290,7 @@ def verify_external_req(
 
     if req.name not in EXTERNAL_REQ_ALLOWLIST and not _unsafe_ignore_allowlist:
         raise InvalidRequires(
-            f"Expected dependency {req.name} to be present in the allowlist"
+            f"Expected dependency {req.name} to be present in the stub_uploader allowlist"
         )
 
     resp = requests.get(f"https://pypi.org/pypi/{upstream_distribution}/json")

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -214,7 +214,7 @@ EXTERNAL_REQ_ALLOWLIST = {
     "Pillow",
     "Werkzeug",
     "arrow",
-    "backports.zoneinfo",
+    "backports.zoneinfo",  # Remove after we drop Python 3.8 support.
     "click",
     "cryptography",
     "django-stubs",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -83,7 +83,9 @@ def test_verify_external_req() -> None:
         Requirement("mypy-extensions"), "mypy", _unsafe_ignore_allowlist=True
     )
 
-    with pytest.raises(InvalidRequires, match="to be present in the allowlist"):
+    with pytest.raises(
+        InvalidRequires, match="to be present in the stub_uploader allowlist"
+    ):
         verify_external_req(Requirement("typing-extensions"), "mypy")
 
     m = Metadata("pandas", {"version": "0.1", "requires": ["numpy"]})


### PR DESCRIPTION
Also improve error message when dependency is missing

backports.zoneinfo is maintained by CPython core developer @pganssle, so it's uncritical. Required for python/typeshed#12706.