### PR TITLE
Fix version date calculation in corner cases

### DIFF
--- a/stub_uploader/get_version.py
+++ b/stub_uploader/get_version.py
@@ -97,7 +97,8 @@ def compute_stub_version(
 
         # But can't keep versioning compatible with upstream...
         is_compatible = False
-        base_version_changed = True
+        # We also use the latest stub version as the base version, not the version_spec.
+        base_version_changed = False
 
     elif version_base.release > max_published.release[:specificity]:
         # For example, version_base=1.2, max_published=1.1.0.4, return 1.2.0.YYYYMMDD

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -110,6 +110,7 @@ def test_compute_stub_version() -> None:
         _stub_ver("~=1.2.3", [f"1.2.3.{TODAY_V}", f"1.2.3.{TOMORROW_V}"])
         == f"1.2.3.{IN_TWO_DAYS_V}"
     )
+    assert _stub_ver("~=1.2.3", [f"1.4.0.{TODAY_V}"]) == f"1.4.0.{TOMORROW_V}"
 
 
 def test_collect_package_data() -> None:


### PR DESCRIPTION
Previously, if the latest published stub version was higher
than the upstream version (which could happen with our old
versioning scheme), we always used the current date as
last component. This failed when uploading the same package
twice in a day – but also in our stub_uploader tests, which
simulate a new upload.