### PR TITLE
Add pyproj to external dependencies allow list

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -231,6 +231,7 @@ EXTERNAL_REQ_ALLOWLIST = {
     "torch",
     "tree-sitter",
     "urllib3",
+    "pyproj",
 }
 
 

--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -226,12 +226,12 @@ EXTERNAL_REQ_ALLOWLIST = {
     "matplotlib",
     "numpy",
     "pandas-stubs",
+    "pyproj",
     "referencing",
     "setuptools",
     "torch",
     "tree-sitter",
     "urllib3",
-    "pyproj",
 }
 
 


### PR DESCRIPTION
This is an important dependency of geopandas which I am adding to typeshed in https://github.com/python/typeshed/pull/12990. It is in the top 1000 PyPI packages https://hugovk.github.io/top-pypi-packages/