### PR TITLE
Check for runtime requirements when depending on external stub packages

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -114,6 +114,17 @@ def test_verify_external_req() -> None:
     with pytest.raises(InvalidRequires, match="no upstream distribution on PyPI"):
         m.requires_external
 
+    # Check differing runtime and stub dependencies
+    verify_external_req(Requirement("pandas-stubs"), "geopandas")
+    with pytest.raises(
+        InvalidRequires,
+        match=(
+            r"Expected dependency pandas to be present in the stub_uploader allowlist"
+            r"\. Did you mean pandas-stubs\?"
+        ),
+    ):
+        verify_external_req(Requirement("pandas"), "geopandas")
+
 
 def test_dependency_order() -> None:
     """Test sort_by_dependency correctly sorts all packages by dependency."""


### PR DESCRIPTION
When a typeshed package depends on an external stub-only package, its runtime package must depend on the corresponding runtime package of the stub-only dependency. For example, [types-geopandas](https://github.com/python/typeshed/pull/12990) requiring `pandas-stubs` means [geopandas](https://github.com/geopandas/geopandas/blob/22345152d9d99a47c88808f763e27bf832ef81e4/pyproject.toml#L27) must require pandas, not pandas-stubs.

Unblocks: https://github.com/python/typeshed/pull/12990