### PR TITLE
Build wheel from sdist

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -443,7 +443,7 @@ def main(
     create_py_typed(metadata, pkg_data, tmpdir)
     copy_changelog(distribution, str(tmpdir))
     subprocess.run(
-        [sys.executable, "-m", "build", "--sdist", "--wheel", "--no-isolation"],
+        [sys.executable, "-m", "build", "--no-isolation"],
         cwd=tmpdir,
     )
     return f"{tmpdir}/dist"


### PR DESCRIPTION
According to [the documentation](https://build.pypa.io/en/stable/#python--m-build),
not passing `--sdist` and `--wheel` will cause the wheel being
built from the sdist, instead of both being built separately.
This is the recommended way to build the packages.