### PR TITLE
[CI] Use Python 3.12

### DIFF
--- a/.github/workflows/force_update.yml
+++ b/.github/workflows/force_update.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Checkout main
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/update_stubs.yml
+++ b/.github/workflows/update_stubs.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Checkout main
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
setuptools in Python 3.11 created non-PEP 625 compliant sdist file names. This has been fixed in Python 3.12.

Closes: #153