### PR TITLE
Add pytest to EXTERNAL_REQ_ALLOWLIST

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -227,6 +227,7 @@ EXTERNAL_REQ_ALLOWLIST = {
     "numpy",
     "pandas-stubs",
     "pyproj",
+    "pytest",
     "referencing",
     "setuptools",
     "torch",


### PR DESCRIPTION
Needed for python/typeshed#13448. I think pytest can definitely be considered trusted.