### PR TITLE
Remove the license trove classifier

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -76,7 +76,6 @@ setup(name=name,
       license="Apache-2.0",
       python_requires="{requires_python}",
       classifiers=[
-          "License :: OSI Approved :: Apache Software License",
           "Programming Language :: Python :: 3",
           "Typing :: Stubs Only",
       ]


### PR DESCRIPTION
PEP 639 deprecates the classifier and setuptools started to issue a warning if it's used:
https://peps.python.org/pep-0639/#deprecate-license-classifiers

Closes: python/typeshed#13738