### PR TITLE
Move metadata from setup.py to pyproject.toml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,8 @@ tomli
 
 # build and upload
 build
-setuptools
+setuptools >= 77.0.3
 twine
-wheel
 
 # tests
 mypy

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -52,34 +52,40 @@ SETUP_TEMPLATE = dedent(
     """
 from setuptools import setup
 
-name = "{stub_distribution}"
-description = "Typing stubs for {distribution}"
-long_description = '''
-{long_description}
-'''.lstrip()
-
-setup(name=name,
-      version="{version}",
-      description=description,
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      url="https://github.com/python/typeshed",
-      project_urls={{
-          "GitHub": "https://github.com/python/typeshed",
-          "Changes": "https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/{distribution}.md",
-          "Issue tracker": "https://github.com/python/typeshed/issues",
-          "Chat": "https://gitter.im/python/typing",
-      }},
-      install_requires={requires},
-      packages={packages},
-      package_data={package_data},
-      license="Apache-2.0",
-      python_requires="{requires_python}",
-      classifiers=[
-          "Programming Language :: Python :: 3",
-          "Typing :: Stubs Only",
-      ]
+setup(package_data={package_data})
+"""
 )
+
+PYPROJECT_TEMPLATE = dedent(
+    """
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools>=77.0.3"]
+
+[project]
+name = "{stub_distribution}"
+version = "{version}"
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+description = "Typing stubs for {distribution}"
+readme = {{ text = \"\"\"\\\n{long_description}\n\"\"\", content-type = "text/markdown" }}
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Typing :: Stubs Only",
+]
+requires-python = "{requires_python}"
+dependencies = {requires}
+
+[project.urls]
+"Homepage" = "https://github.com/python/typeshed"
+"GitHub" = "https://github.com/python/typeshed"
+"Changes" = "https://github.com/typeshed-internal/stub_uploader/blob/main/data/changelogs/{distribution}.md"
+"Issue tracker" = "https://github.com/python/typeshed/issues"
+"Chat" = "https://gitter.im/python/typing"
+
+[tool.setuptools]
+packages = {packages}
+include-package-data = false
 """
 ).lstrip()
 
@@ -339,7 +345,12 @@ def is_ignored_distribution_file(entry: Path) -> bool:
     return False
 
 
-def generate_setup_file(
+def generate_setup_file(pkg_data: PackageData) -> str:
+    """Auto-generate a setup.py file for given distribution using a template."""
+    return SETUP_TEMPLATE.format(package_data=pkg_data.package_data)
+
+
+def generate_pyproject_file(
     ts_data: TypeshedData,
     build_data: BuildData,
     pkg_data: PackageData,
@@ -355,7 +366,7 @@ def generate_setup_file(
         if metadata.requires_python is not None
         else f">={ts_data.oldest_supported_python}"
     )
-    return SETUP_TEMPLATE.format(
+    return PYPROJECT_TEMPLATE.format(
         distribution=build_data.distribution,
         stub_distribution=metadata.stub_distribution,
         long_description=generate_long_description(
@@ -364,7 +375,6 @@ def generate_setup_file(
         version=version,
         requires=all_requirements,
         packages=pkg_data.top_level_packages,
-        package_data=pkg_data.package_data,
         requires_python=requires_python,
     )
 
@@ -440,8 +450,9 @@ def main(
     else:
         tmpdir = Path(tempfile.mkdtemp())
 
-    (tmpdir / "setup.py").write_text(
-        generate_setup_file(ts_data, build_data, pkg_data, metadata, version)
+    (tmpdir / "setup.py").write_text(generate_setup_file(pkg_data))
+    (tmpdir / "pyproject.toml").write_text(
+        generate_pyproject_file(ts_data, build_data, pkg_data, metadata, version)
     )
     copy_stubs(build_data.stub_dir, tmpdir)
     create_py_typed(metadata, pkg_data, tmpdir)


### PR DESCRIPTION
> [!NOTE]
> I explicitly chose to set `include-package-data = false` to continue to rely on the explicit declaration of package data files. Due to a bug in setuptools, it's not possible (yet) to define package-data for stub packages. (Will be fixed upstream with https://github.com/abravalheri/validate-pyproject/pull/248). If the build folder only contains the stub files + `py.typed` + `METADATA.toml` to begin with anyway (i.e. all files should be included in the wheel), it would be enough to just remove `package-data` completely and rely on `include-package-data = true` instead (usually the default for `pyproject.toml` configs). Might be better to tackle that one separately in #160. /CC @Avasam

Setuptools `v77.0.3` added support for PEP 639. It requires Python 3.9 which is the current min version, so shouldn't be an issue.

Metadata diff
```diff
 ...
-License: Apache-2.0
+License-Expression: Apache-2.0
-Home-page: https://github.com/python/typeshed
+Project-URL: Homepage, https://github.com/python/typeshed
 ...
 Requires-Python: >=3.9
 ...
 License-File: LICENSE
 ...
-Dynamic: classifier
-Dynamic: description
-Dynamic: description-content-type
-Dynamic: home-page
-Dynamic: license
 Dynamic: license-file
-Dynamic: project-url
-Dynamic: requires-dist
-Dynamic: requires-python
-Dynamic: summary
 ...
```