### PR TITLE
Remove `backports.zoneinfo` for ext req allowlist

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -218,7 +218,6 @@ EXTERNAL_REQ_ALLOWLIST = {
     "Pillow",
     "Werkzeug",
     "arrow",
-    "backports.zoneinfo",  # Remove after we drop Python 3.8 support.
     "click",
     "cryptography",
     "django-stubs",


### PR DESCRIPTION
`zoneinfo` is part of the Python standard library since Python 3.9.