### PR TITLE
Integration tests: Check for files existing

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -231,9 +231,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert name.isidentifier(), (
-                    "All file names must be valid Python modules"
-                )
+                assert (
+                    name.isidentifier()
+                ), "All file names must be valid Python modules"
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -231,9 +231,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert (
-                    name.isidentifier()
-                ), "All file names must be valid Python modules"
+                assert name.isidentifier(), (
+                    "All file names must be valid Python modules"
+                )
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))
@@ -430,7 +430,7 @@ def generate_long_description(
 
 def main(
     typeshed_dir: str, distribution: str, version: str, build_dir: str | None = None
-) -> str:
+) -> Path:
     """Generate a wheel for a third-party distribution in typeshed.
 
     Return the path to directory where wheel is created.
@@ -470,7 +470,7 @@ def main(
         [sys.executable, "-m", "build", "--no-isolation"],
         cwd=tmpdir,
     )
-    return f"{tmpdir}/dist"
+    return Path(tmpdir) / "dist"
 
 
 if __name__ == "__main__":
@@ -480,7 +480,7 @@ if __name__ == "__main__":
     parser.add_argument("distribution", help="Third-party distribution to build")
     parser.add_argument("version", help="New stub version")
     args = parser.parse_args()
-    print(
-        "Wheel is built in:",
-        main(args.typeshed_dir, args.distribution, args.version, args.build_dir),
+    build_path = main(
+        args.typeshed_dir, args.distribution, args.version, args.build_dir
     )
+    print(f"Wheel is built in: {build_path}")

--- a/stub_uploader/upload.py
+++ b/stub_uploader/upload.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import subprocess
 
 from stub_uploader import build_wheel
@@ -47,7 +46,7 @@ def upload_distribution(
     if dry_run or not metadata.upload:
         print("skipped")
     else:
-        subprocess.run(["twine", "upload", os.path.join(temp_dir, "*")], check=True)
+        subprocess.run(["twine", "upload", str(temp_dir / "*")], check=True)
         uploaded_packages.add(distribution)
         print("ok")
     print()


### PR DESCRIPTION
In particular, this checks whether namespace packages
include *.pyi files.

* Return `Path` not `str` from `build_wheel.main()`.
* Delete temporary directories while running integration tests.