### PR TITLE
Remove support for pytype

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -2,13 +2,8 @@
 Basic script to generate a wheel for a third-party distribution in typeshed.
 
 This generates a PEP 561 types stub package using METADATA.toml file for a given
-distribution in typeshed stubs. Such package
-can be used by type-checking tools like
-[mypy](https://github.com/python/mypy/),
-[pyright](https://github.com/microsoft/pyright),
-[pytype](https://github.com/google/pytype/),
-PyCharm, etc. to check code that uses
-the corresponding runtime Python package.
+distribution in typeshed stubs. Such package can be used by type checkers
+to check code that uses the corresponding runtime Python package.
 
 The generated wheel includes all type stubs (*.pyi files) and the METADATA.toml
 itself, no other files can be included.
@@ -102,14 +97,9 @@ package if you use this or a newer version.
 DESCRIPTION_INTRO_TEMPLATE = """
 ## Typing stubs for {distribution}
 
-This is a [PEP 561](https://peps.python.org/pep-0561/)
-type stub package for the {formatted_distribution} package.
-It can be used by type-checking tools like
-[mypy](https://github.com/python/mypy/),
-[pyright](https://github.com/microsoft/pyright),
-[pytype](https://github.com/google/pytype/),
-[Pyre](https://pyre-check.org/),
-PyCharm, etc. to check code that uses `{distribution}`. This version of
+This is a [PEP 561](https://peps.python.org/pep-0561/) type stub package for
+the {formatted_distribution} package. It can be used by type checkers
+to check code that uses `{distribution}`. This version of
 `{stub_distribution}` aims to provide accurate annotations for
 `{distribution}{typeshed_version_spec}`.
 """.strip()
@@ -122,10 +112,9 @@ for more details. The source for this package can be found in the
 [`stubs/{distribution}`](https://github.com/python/typeshed/tree/main/stubs/{distribution})
 directory.
 
-This package was tested with
-mypy {ts_data.mypy_version},
-pyright {ts_data.pyright_version},
-and pytype {ts_data.pytype_version}.
+This package was tested with the following type checkers:
+* [mypy](https://github.com/python/mypy/) {ts_data.mypy_version}
+* [pyright](https://github.com/microsoft/pyright) {ts_data.pyright_version}
 It was generated from typeshed commit
 [`{commit}`](https://github.com/python/typeshed/commit/{commit}).
 """.strip()
@@ -231,9 +220,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert (
-                    name.isidentifier()
-                ), "All file names must be valid Python modules"
+                assert name.isidentifier(), (
+                    "All file names must be valid Python modules"
+                )
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -220,9 +220,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert name.isidentifier(), (
-                    "All file names must be valid Python modules"
-                )
+                assert (
+                    name.isidentifier()
+                ), "All file names must be valid Python modules"
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))

--- a/stub_uploader/ts_data.py
+++ b/stub_uploader/ts_data.py
@@ -24,7 +24,6 @@ class TypeshedData:
     typeshed_path: Path
     mypy_version: Version
     pyright_version: Version
-    pytype_version: Version
     oldest_supported_python: str
 
     def read_current_commit(self) -> str:
@@ -48,7 +47,6 @@ def read_typeshed_data(typeshed_path: Path) -> TypeshedData:
         typeshed_path=typeshed_path,
         mypy_version=Version(requirements["mypy"]),
         pyright_version=Version(requirements["pyright"]),
-        pytype_version=Version(requirements["pytype"]),
         oldest_supported_python=typeshed_table["oldest_supported_python"],
     )
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -226,17 +226,12 @@ def _build_requirements(
     *,
     mypy: str | None = "1.11.1",
     pyright: str | None = "1.1.381",
-    pytype: (
-        str | None
-    ) = '2024.9.13; platform_system != "Windows" and python_version < "3.13"',
 ) -> str:
     req = _REQUIREMENTS_TXT
     if mypy is not None:
         req += f"\nmypy=={mypy}"
     if pyright is not None:
         req += f"\npyright=={pyright}"
-    if pytype is not None:
-        req += f"\npytype=={pytype}"
     return req
 
 


### PR DESCRIPTION
Also improve the generated package descriptions:

* List type checkers using a markdown list.
* Link the type checkers in that list.
* Instead remove the mention of specific type checkers from the
  introduction. (This removes mentions of pyre and PyCharm,
  but I assume that at some point we will add pyrefly to the supported
  type checkers anyway.)
* Use "type checkers" instead of "type-checking tools".