### PR TITLE
Add websockets to external requirements allow list

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -234,6 +234,7 @@ EXTERNAL_REQ_ALLOWLIST = {
     "torch",
     "tree-sitter",
     "urllib3",
+    "websockets",
 }
 
 # Map of external stub packages to their runtime equivalent.


### PR DESCRIPTION
https://pypi.org/project/websockets/

websockets is a foundational library for full HTTP support, used by many other trusted libraries with ~80.000.000 downloads per months.

Required for python/typeshed#14216