### PR TITLE
Fix formatting of type checker list in generated package descriptions

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -115,6 +115,7 @@ directory.
 This package was tested with the following type checkers:
 * [mypy](https://github.com/python/mypy/) {ts_data.mypy_version}
 * [pyright](https://github.com/microsoft/pyright) {ts_data.pyright_version}
+
 It was generated from typeshed commit
 [`{commit}`](https://github.com/python/typeshed/commit/{commit}).
 """.strip()


### PR DESCRIPTION
Without a blank line, the "It was generated ..." sentence gets rendered inside the pyright bullet.

See e.g. https://pypi.org/project/types-braintree/4.38.0.20250807/