### PR TITLE
Prettify changelogs

### DIFF
--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -38,6 +38,7 @@ def test_ensure_specificity() -> None:
     assert ver == [1, 2, 3, 4, 5]
 
 
+DISTRIBUTION = "setuptools"
 TODAY = datetime.date(2024, 9, 12)
 TODAY_V = TODAY.strftime("%Y%m%d")
 TOMORROW_V = "20240913"
@@ -336,16 +337,28 @@ commit 337fd828e819988af2d3600283d8068bbbab7f50
     Bump setuptools to 80.7.* (#14069)
     
     Body text #12345 python/typeshed#12345 https://example.com/#123
+
+commit 58f581cea1a5040a733e6284adf81bf0793ac26a
+
+    [tqdm] Update to 4.67.2 (#15348)
+
+    Closes: #15347
+    Diff: https://github.com/tqdm/tqdm/compare/v4.67.1...v4.67.2
 """
     expected_entry = f"""\
-## 80.7.0.{TODAY_V} ({TODAY:%Y-%m-%d})
+## [80.7.0.{TODAY_V}](https://pypi.org/project/types-{DISTRIBUTION}/80.7.0.{TODAY_V}/) ({TODAY:%Y-%m-%d})
 
-Replace `Incomplete | None = None` in third party stubs ([#14063](https://github.com/python/typeshed/pull/14063))
+* Replace `Incomplete | None = None` in third party stubs ([#14063](https://github.com/python/typeshed/pull/14063))
 
-Bump setuptools to 80.7.* ([#14069](https://github.com/python/typeshed/pull/14069))
+* Bump setuptools to 80.7.* ([#14069](https://github.com/python/typeshed/pull/14069))
 
-Body text #12345 python/typeshed#12345 https://example.com/#123
+    Body text #12345 python/typeshed#12345 https://example.com/#123
+
+* Update to 4.67.2 ([#15348](https://github.com/python/typeshed/pull/15348))
+
+    Closes: #15347 \\
+    Diff: https://github.com/tqdm/tqdm/compare/v4.67.1...v4.67.2
 
 """
-    actual_entry = process_git_log(git_log, f"80.7.0.{TODAY_V}", TODAY)
+    actual_entry = process_git_log(git_log, DISTRIBUTION, f"80.7.0.{TODAY_V}", TODAY)
     assert actual_entry == expected_entry


### PR DESCRIPTION
* Remove scope prefix for commit titles (It doesn't seem to make sense for package changelog)
* Add indentation to commit description
* Add ' \\' for correct line breaks
* Add link to PyPI release in header (This is debatable, and I’m not sure how useful this would be, as the raw Markdown may not be very readable)

### `Authlib.md` changelog example:

| After | Before |
|----------|--------|
| <img width="1039" height="1327" alt="scrn21" src="https://github.com/user-attachments/assets/9959b05d-97d3-428c-b91f-c51448b51edd" /> | <img width="1039" height="1327" alt="scrn22" src="https://github.com/user-attachments/assets/7168564a-ba6b-4227-8c8b-96f8d2da5f52" /> |

| After | Before |
|----------|--------|
| <img width="1039" height="1327" alt="scrn31" src="https://github.com/user-attachments/assets/dc5f5c8f-0f50-470e-89ee-140bc074d926" /> | <img width="1633" height="1327" alt="scrn32" src="https://github.com/user-attachments/assets/2ce845fb-1e0c-4f96-81b0-4e5df3121c9c" /> |