### PR TITLE
Add requests to extenal dep allowlist

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -234,6 +234,7 @@ EXTERNAL_REQ_ALLOWLIST = {
     "pyproj",
     "pytest",
     "referencing",
+    "requests",
     "setuptools",
     "torch",
     "tree-sitter",


### PR DESCRIPTION
requests has recently added type hints, so our own types-requests package has become obsolete.

Required by python/typeshed#15813