### PR TITLE
Replace requests-oauthlib with JACK-Client in tests

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -174,7 +174,8 @@ def test_recursive_verify_single() -> None:
 
     m = read_metadata(TYPESHED, "JACK-Client")
     assert recursive_verify(m, TYPESHED) == {
-        "types-cffi",
+        "types-JACK-Client",
+        "types-cffi",  # direct dependency
         "types-setuptools",  # indirect dependency via types-cffi
     }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -172,11 +172,10 @@ def test_recursive_verify_single() -> None:
     m = read_metadata(TYPESHED, "six")
     assert recursive_verify(m, TYPESHED) == {"types-six"}
 
-    m = read_metadata(TYPESHED, "requests-oauthlib")
+    m = read_metadata(TYPESHED, "JACK-Client")
     assert recursive_verify(m, TYPESHED) == {
-        "types-requests-oauthlib",
-        "types-requests",
-        "types-oauthlib",
+        "types-cffi",
+        "types-setuptools",  # indirect dependency via types-cffi
     }
 
 


### PR DESCRIPTION
requests-oauthlib used to depend on types-requests, but will change its dependency to requests, since that gained type annotations. The recursive dependencies check therefore needs another package.