### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/check_scripts.yml
+++ b/.github/workflows/check_scripts.yml
@@ -12,10 +12,10 @@ jobs:
     name: Check formatting with black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
         with:
           python-version: '3.13'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
       - run: pip install -r requirements.txt
       - run: |
           black --version
@@ -25,10 +25,10 @@ jobs:
     name: Check stub_uploader with mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
         with:
           python-version: '3.13'
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
       - run: pip install -r requirements.txt
       - run: mypy --strict -p stub_uploader -p tests
 
@@ -37,16 +37,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
         with:
           # Keep in sync with typeshed's daily.yml and tests.yml workflows.
           python-version: '3.13'
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
         with:
           path: main
       - name: Checkout typeshed
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
         with:
           repository: python/typeshed
           path: typeshed

--- a/.github/workflows/force_update.yml
+++ b/.github/workflows/force_update.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
         with:
           python-version: '3.13'
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
         with:
           path: main
       - name: Checkout typeshed
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
         with:
           repository: python/typeshed
           path: typeshed

--- a/.github/workflows/test_api_token.yml
+++ b/.github/workflows/test_api_token.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
       with:
         python-version: '3.13'
     - name: Install dependencies

--- a/.github/workflows/update_stubs.yml
+++ b/.github/workflows/update_stubs.yml
@@ -16,15 +16,15 @@ jobs:
     if: ${{ github.repository == 'typeshed-internal/stub_uploader' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
         with:
           python-version: '3.13'
       - name: Checkout main
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
         with:
           path: main
       - name: Checkout typeshed
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
         with:
           repository: python/typeshed
           path: typeshed


### PR DESCRIPTION
GitHub doesn't seem to use immutable releases for their own actions, so we're using commit hashes for now.

* https://github.com/actions/checkout/releases/tag/v6.0.3
* https://github.com/actions/setup-python/releases/tag/v6.2.0