### PR TITLE
Unpin requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # scripts
 packaging
-requests < 2.30.0
+requests
 
 # build and upload
 build


### PR DESCRIPTION
It was originally pinned in #95 in 2023, because of CI failures with the new (at the time) requests 2.30.0. This was due to some interaction of requests and urllib3 (see psf/requests#6439). This has been fixed for a long time.

Cc @AlexWaygood 