### PR TITLE
Refactor type checkers

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -221,9 +221,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert (
-                    name.isidentifier()
-                ), "All file names must be valid Python modules"
+                assert name.isidentifier(), (
+                    "All file names must be valid Python modules"
+                )
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))
@@ -428,9 +428,9 @@ def generate_long_description(
         DESCRIPTION_OUTRO_TEMPLATE.format(
             distribution=distribution,
             commit=commit,
-            type_checkers=[
+            type_checkers="\n".join(
                 f"* [{tc.name}]({tc.url}) {tc.version}" for tc in ts_data.type_checkers
-            ],
+            ),
         )
     )
     return "\n\n".join(parts)

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -49,7 +49,8 @@ This stub package is marked as [partial](https://typing.python.org/en/latest/spe
 If you find that annotations are missing, feel free to contribute and help complete them.
 """.lstrip()
 
-PYPROJECT_TEMPLATE = dedent("""
+PYPROJECT_TEMPLATE = dedent(
+    """
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=82.0.1"]
@@ -83,7 +84,8 @@ include-package-data = false
 
 [tool.setuptools.package-data]
 {package_data}
-""").lstrip()
+"""
+).lstrip()
 
 NO_LONGER_UPDATED_TEMPLATE = """
 *Note:* `{stub_distribution}` is unmaintained and won't be updated.

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -118,6 +118,7 @@ directory.
 This package was tested with the following type checkers:
 * [mypy](https://github.com/python/mypy/) {ts_data.mypy_version}
 * [pyright](https://github.com/microsoft/pyright) {ts_data.pyright_version}
+* [ty](https://docs.astral.sh/ty/) {ts_data.ty_version}
 
 It was generated from typeshed commit
 [`{commit}`](https://github.com/python/typeshed/commit/{commit}).
@@ -224,9 +225,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert (
-                    name.isidentifier()
-                ), "All file names must be valid Python modules"
+                assert name.isidentifier(), (
+                    "All file names must be valid Python modules"
+                )
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -116,9 +116,7 @@ for more details. The source for this package can be found in the
 directory.
 
 This package was tested with the following type checkers:
-* [mypy](https://github.com/python/mypy/) {ts_data.mypy_version}
-* [pyright](https://github.com/microsoft/pyright) {ts_data.pyright_version}
-* [ty](https://docs.astral.sh/ty/) {ts_data.ty_version}
+{type_checkers}
 
 It was generated from typeshed commit
 [`{commit}`](https://github.com/python/typeshed/commit/{commit}).
@@ -225,9 +223,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert (
-                    name.isidentifier()
-                ), "All file names must be valid Python modules"
+                assert name.isidentifier(), (
+                    "All file names must be valid Python modules"
+                )
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))
@@ -432,7 +430,9 @@ def generate_long_description(
         DESCRIPTION_OUTRO_TEMPLATE.format(
             distribution=distribution,
             commit=commit,
-            ts_data=ts_data,
+            type_checkers=[
+                f"* [{tc.name}]({tc.url}) {tc.version}" for tc in ts_data.type_checkers
+            ],
         )
     )
     return "\n\n".join(parts)

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -225,9 +225,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert name.isidentifier(), (
-                    "All file names must be valid Python modules"
-                )
+                assert (
+                    name.isidentifier()
+                ), "All file names must be valid Python modules"
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -221,9 +221,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert name.isidentifier(), (
-                    "All file names must be valid Python modules"
-                )
+                assert (
+                    name.isidentifier()
+                ), "All file names must be valid Python modules"
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -49,8 +49,7 @@ This stub package is marked as [partial](https://typing.python.org/en/latest/spe
 If you find that annotations are missing, feel free to contribute and help complete them.
 """.lstrip()
 
-PYPROJECT_TEMPLATE = dedent(
-    """
+PYPROJECT_TEMPLATE = dedent("""
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = ["setuptools>=82.0.1"]
@@ -84,8 +83,7 @@ include-package-data = false
 
 [tool.setuptools.package-data]
 {package_data}
-"""
-).lstrip()
+""").lstrip()
 
 NO_LONGER_UPDATED_TEMPLATE = """
 *Note:* `{stub_distribution}` is unmaintained and won't be updated.
@@ -223,9 +221,9 @@ def find_stub_files(top: str) -> list[str]:
         for file in files:
             if file.endswith(".pyi"):
                 name, _ = os.path.splitext(file)
-                assert name.isidentifier(), (
-                    "All file names must be valid Python modules"
-                )
+                assert (
+                    name.isidentifier()
+                ), "All file names must be valid Python modules"
                 result.append(os.path.relpath(os.path.join(root, file), top))
             elif file == "py.typed":
                 result.append(os.path.relpath(os.path.join(root, file), top))

--- a/stub_uploader/const.py
+++ b/stub_uploader/const.py
@@ -8,3 +8,12 @@ TYPES_PREFIX = "types-"
 _ROOT = pathlib.Path(__file__).parent.parent
 CHANGELOG_PATH = (_ROOT / "data" / "changelogs").resolve()
 UPLOADED_PATH = str((_ROOT / "data" / "uploaded_packages.txt").resolve())
+
+REQUIREMENTS = "requirements-tests.txt"
+PYPROJECT = "pyproject.toml"
+
+TYPE_CHECKERS = [
+    ("mypy", "https://github.com/python/mypy/"),
+    ("pyright", "https://github.com/microsoft/pyright"),
+    ("ty", "https://docs.astral.sh/ty/"),
+]

--- a/stub_uploader/ts_data.py
+++ b/stub_uploader/ts_data.py
@@ -15,15 +15,8 @@ import tomllib
 from packaging.requirements import Requirement
 from packaging.version import Version
 
-REQUIREMENTS = "requirements-tests.txt"
-PYPROJECT = "pyproject.toml"
-
-TYPE_CHECKERS = [
-    ("mypy", "https://github.com/python/mypy/"),
-    ("pyright", "https://github.com/microsoft/pyright"),
-    ("ty", "https://docs.astral.sh/ty/"),
-]
-
+from stub_uploader.const import PYPROJECT, REQUIREMENTS, TYPE_CHECKERS
+ 
 
 @dataclass
 class TypeChecker:

--- a/stub_uploader/ts_data.py
+++ b/stub_uploader/ts_data.py
@@ -18,14 +18,25 @@ from packaging.version import Version
 REQUIREMENTS = "requirements-tests.txt"
 PYPROJECT = "pyproject.toml"
 
+TYPE_CHECKERS = [
+    ("mypy", "https://github.com/python/mypy/"),
+    ("pyright", "https://github.com/microsoft/pyright"),
+    ("ty", "https://docs.astral.sh/ty/"),
+]
+
+
+@dataclass
+class TypeChecker:
+    name: str
+    version: Version
+    url: str
+
 
 @dataclass
 class TypeshedData:
     typeshed_path: Path
-    mypy_version: Version
-    pyright_version: Version
-    ty_version: Version
     oldest_supported_python: str
+    type_checkers: list[TypeChecker]
 
     def read_current_commit(self) -> str:
         return subprocess.run(
@@ -39,18 +50,22 @@ class TypeshedData:
 def read_typeshed_data(typeshed_path: Path) -> TypeshedData:
     with (typeshed_path / PYPROJECT).open("rb") as f:
         pyproject = tomllib.load(f)
-    with (typeshed_path / REQUIREMENTS).open() as f:
-        requirements = parse_requirements(f)
     typeshed_table = pyproject["tool"]["typeshed"]
     oldest_supported_python = typeshed_table.get("oldest-supported-python", "")
     if not re.match(r"^\d+\.\d+$", oldest_supported_python):
         raise ValueError("Invalid oldest-supported-python in pyproject.toml")
+
+    with (typeshed_path / REQUIREMENTS).open() as f:
+        requirements = parse_requirements(f)
+    type_checkers = [
+        TypeChecker(name, Version(requirements[name]), url)
+        for name, url in TYPE_CHECKERS
+    ]
+
     return TypeshedData(
         typeshed_path=typeshed_path,
-        mypy_version=Version(requirements["mypy"]),
-        pyright_version=Version(requirements["pyright"]),
-        ty_version=Version(requirements["ty"]),
         oldest_supported_python=oldest_supported_python,
+        type_checkers=type_checkers,
     )
 
 

--- a/stub_uploader/ts_data.py
+++ b/stub_uploader/ts_data.py
@@ -16,7 +16,7 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 from stub_uploader.const import PYPROJECT, REQUIREMENTS, TYPE_CHECKERS
- 
+
 
 @dataclass
 class TypeChecker:

--- a/stub_uploader/ts_data.py
+++ b/stub_uploader/ts_data.py
@@ -24,6 +24,7 @@ class TypeshedData:
     typeshed_path: Path
     mypy_version: Version
     pyright_version: Version
+    ty_version: Version
     oldest_supported_python: str
 
     def read_current_commit(self) -> str:
@@ -48,6 +49,7 @@ def read_typeshed_data(typeshed_path: Path) -> TypeshedData:
         typeshed_path=typeshed_path,
         mypy_version=Version(requirements["mypy"]),
         pyright_version=Version(requirements["pyright"]),
+        ty_version=Version(requirements["ty"]),
         oldest_supported_python=oldest_supported_python,
     )
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -16,6 +16,7 @@ from stub_uploader.build_wheel import (
     collect_package_data,
     generate_optional_dependencies_table,
 )
+from stub_uploader.const import TYPE_CHECKERS
 from stub_uploader.get_version import compute_stub_version, ensure_specificity
 from stub_uploader.metadata import (
     Dependency,
@@ -24,7 +25,6 @@ from stub_uploader.metadata import (
     strip_types_prefix,
 )
 from stub_uploader.ts_data import (
-    TYPE_CHECKERS,
     TypeChecker,
     TypeshedData,
     parse_requirements,

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -245,7 +245,7 @@ def _build_requirements(
     if pyright is not None:
         req += f"\npyright=={pyright}"
     if ty is not None:
-        req += f"\nty={ty}"
+        req += f"\nty=={ty}"
     return req
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -23,7 +23,12 @@ from stub_uploader.metadata import (
     _UploadedPackages,
     strip_types_prefix,
 )
-from stub_uploader.ts_data import TypeshedData, parse_requirements, read_typeshed_data
+from stub_uploader.ts_data import (
+    TypeChecker,
+    TypeshedData,
+    parse_requirements,
+    read_typeshed_data,
+)
 from stub_uploader.update_changelog import process_git_log
 
 
@@ -262,7 +267,9 @@ def test_read_typeshed_data__success() -> None:
     req = _build_requirements(mypy="1.11.1")
     data = _test_typeshed_data(pp, req)
     assert data.oldest_supported_python == "3.10"
-    assert data.mypy_version == Version("1.11.1")
+    assert data.type_checkers[0] == TypeChecker(
+        "mypy", Version("1.11.1"), "https://github.com/python/mypy/"
+    )
 
 
 def test_read_typeshed_data__oldest_python_missing() -> None:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -237,12 +237,15 @@ def _build_requirements(
     *,
     mypy: str | None = "1.11.1",
     pyright: str | None = "1.1.381",
+    ty: str | None = "0.0.59",
 ) -> str:
     req = _REQUIREMENTS_TXT
     if mypy is not None:
         req += f"\nmypy=={mypy}"
     if pyright is not None:
         req += f"\npyright=={pyright}"
+    if ty is not None:
+        req += f"\nty={ty}"
     return req
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -24,6 +24,7 @@ from stub_uploader.metadata import (
     strip_types_prefix,
 )
 from stub_uploader.ts_data import (
+    TYPE_CHECKERS,
     TypeChecker,
     TypeshedData,
     parse_requirements,
@@ -238,19 +239,13 @@ no_version
 """
 
 
-def _build_requirements(
-    *,
-    mypy: str | None = "1.11.1",
-    pyright: str | None = "1.1.381",
-    ty: str | None = "0.0.59",
-) -> str:
+def _build_requirements(*, mypy: str | None = "1.11.1") -> str:
     req = _REQUIREMENTS_TXT
     if mypy is not None:
         req += f"\nmypy=={mypy}"
-    if pyright is not None:
-        req += f"\npyright=={pyright}"
-    if ty is not None:
-        req += f"\nty=={ty}"
+    for tc in TYPE_CHECKERS:
+        if tc[0] != "mypy":
+            req += f"\n{tc[0]}==1.0.0"
     return req
 
 


### PR DESCRIPTION
Instead of hard-coding the type checkers in multiple places, add a central `TYPE_CHECKERS` list.

Also add a `TypeChecker` data class to store all data about a single type checker (name, version, URL).

Depends on #211.