### PR TITLE
Update URLs for mypy and pyright

### DIFF
--- a/stub_uploader/const.py
+++ b/stub_uploader/const.py
@@ -13,7 +13,7 @@ REQUIREMENTS = "requirements-tests.txt"
 PYPROJECT = "pyproject.toml"
 
 TYPE_CHECKERS = [
-    ("mypy", "https://github.com/python/mypy/"),
-    ("pyright", "https://github.com/microsoft/pyright"),
+    ("mypy", "https://www.mypy-lang.org/"),
+    ("pyright", "https://microsoft.github.io/pyright/"),
     ("ty", "https://docs.astral.sh/ty/"),
 ]

--- a/stub_uploader/ts_data.py
+++ b/stub_uploader/ts_data.py
@@ -16,7 +16,7 @@ from packaging.requirements import Requirement
 from packaging.version import Version
 
 from stub_uploader.const import PYPROJECT, REQUIREMENTS, TYPE_CHECKERS
- 
+
 
 @dataclass
 class TypeChecker:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -263,7 +263,7 @@ def test_read_typeshed_data__success() -> None:
     data = _test_typeshed_data(pp, req)
     assert data.oldest_supported_python == "3.10"
     assert data.type_checkers[0] == TypeChecker(
-        "mypy", Version("1.11.1"), "https://github.com/python/mypy/"
+        "mypy", Version("1.11.1"), "https://www.mypy-lang.org/"
     )
 
 


### PR DESCRIPTION
Use the marketing URLs, not the GitHub repository

Depends on #214 