### PR TITLE
Pin packaging to 26.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # scripts
-packaging
+packaging == 26.2  # see issue #220, needs investigation
 requests
 
 # build and upload


### PR DESCRIPTION
packaging 26.3 crashes the stub_upload for unknown reasons. See #220.