### PR TITLE
Add `affine` to allowlist

### DIFF
--- a/stub_uploader/metadata.py
+++ b/stub_uploader/metadata.py
@@ -272,6 +272,7 @@ EXTERNAL_REQ_ALLOWLIST = {
     "MarkupSafe",
     "Pillow",
     "Werkzeug",
+    "affine",
     "arrow",
     "asgiref",
     "beautifulsoup4",


### PR DESCRIPTION
I think this is why https://github.com/python/typeshed/pull/16180 is failing? `affine` is a pretty well used package by lots of geospatial and data science packages so think it should be allowed in the list if this is the fix necessary.