### PR TITLE
Run linters/formatters via pre-commit

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
-      - uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
+        with:
+          python-version: '3.13'
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # 3.0.1
 
   mypy:
     name: Check stub_uploader with mypy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,18 +8,12 @@ env:
   FORCE_COLOR: 1
 
 jobs:
-  black:
-    name: Check formatting with black
+  pre-commit:
+    name: Check pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
-        with:
-          python-version: '3.13'
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
-      - run: pip install -r requirements.txt
-      - run: |
-          black --version
-          black --check .
+      - uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16 # v2.0.6
 
   mypy:
     name: Check stub_uploader with mypy

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,10 +12,10 @@ jobs:
     name: Check pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
         with:
           python-version: '3.13'
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # 3.0.1
 
   mypy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-      - id: check-toml
       - id: check-merge-conflict
       - id: mixed-line-ending
         args: [--fix=lf]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,33 @@
+# generated files -- trailing whitespace etc. doesn't matter too much for these
+exclude: (?x)^(data/.*)$
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # frozen: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-case-conflict
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 12e63946db2c5cfcc9030fac21c3883ba88c6ed8 # frozen: 0.38.0
+    hooks:
+      - id: check-github-workflows
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 4160603246a6b365d4a2af661c6d71b0a0f50478 # frozen: 26.5.1
+    hooks:
+      - id: black
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+
+ci:
+  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
+  autoupdate_schedule: quarterly
+  submodules: false

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The directory layout is self-explanatory:
 There are four GitHub actions in the repository. Here is a brief explanation
 of the role of each action.
 
-### Check scripts (CI)
+### Check (CI)
 
-[This CI action](https://github.com/typeshed-internal/stub_uploader/actions?query=workflow%3A%22Check+scripts%22)
-simply runs mypy and tests on each PR and push. You don't need to run it manually.
+[This CI action](https://github.com/typeshed-internal/stub_uploader/actions?query=workflow%3A%22Check%22)
+simply runs mypy, linters/formatters and tests on each PR and push. You don't need to run it manually.
 
 ### Test PyPI API token
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,3 @@ twine
 mypy
 pytest
 types-requests
-
-# formatting
-black >= 26.5.1, < 27

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -349,7 +349,7 @@ commit 126768408a69b7a3a09b7d3992970b289f92937e
 commit 337fd828e819988af2d3600283d8068bbbab7f50
 
     Bump setuptools to 80.7.* (#14069)
-    
+
     Body text #12345 python/typeshed#12345 https://example.com/#123
 
 commit 58f581cea1a5040a733e6284adf81bf0793ac26a


### PR DESCRIPTION
This will make it easier to add more security and correctness linters to CI in followup PRs. This is a similar pattern to what we already use in typeshed and typing_extensions