### PR TITLE
Add zizmor hook and fix workflow security findings

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
@@ -12,20 +15,24 @@ jobs:
     name: Check pre-commit hooks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.13'
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # 3.0.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
 
   mypy:
     name: Check stub_uploader with mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.13'
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
       - run: pip install -r requirements.txt
       - run: mypy --strict -p stub_uploader -p tests
 
@@ -34,19 +41,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           # Keep in sync with typeshed's daily.yml and tests.yml workflows.
           python-version: '3.13'
       - name: Checkout main
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           path: main
+          persist-credentials: false
       - name: Checkout typeshed
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           repository: python/typeshed
           path: typeshed
+          persist-credentials: false
       - name: Run tests
         run: |
           cd main

--- a/.github/workflows/force_update.yml
+++ b/.github/workflows/force_update.yml
@@ -7,37 +7,45 @@ on:
         description: 'Package name or pattern (Python regexp)'
         required: true
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.13'
       - name: Checkout main
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           path: main
+          # Needed to push updates to the uploaded packages list.
+          persist-credentials: true
       - name: Checkout typeshed
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           repository: python/typeshed
           path: typeshed
+          persist-credentials: false
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r main/requirements.txt
       - name: Execute build and upload
         env:
+          DISTRIBUTION: ${{ github.event.inputs.distribution }}
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TYPESHED_BOT_API_TOKEN }}
         run: |
           cd main
-          python -m stub_uploader.upload_some ../typeshed "${{ github.event.inputs.distribution }}"
+          python -m stub_uploader.upload_some ../typeshed "$DISTRIBUTION"
           # If we are force uploading packages that were never uploaded, they are added to the list
           if [ -z "$(git status --porcelain)" ]; then
               exit 0;

--- a/.github/workflows/test_api_token.yml
+++ b/.github/workflows/test_api_token.yml
@@ -9,6 +9,9 @@ on:
         required: true
         default: 0
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
 
@@ -17,20 +20,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      with:
+        persist-credentials: false
     - name: Set up Python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build setuptools wheel twine
-    - name: Build and publish
+    # This workflow specifically tests API-token authentication.
+    - name: Build and publish  # zizmor: ignore[use-trusted-publishing]
       env:
+        PACKAGE_VERSION_INCREMENT: ${{ github.event.inputs.increment }}
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.TYPESHED_BOT_API_TOKEN }}
       run: |
         cd data/empty_package
-        PACKAGE_VERSION_INCREMENT=${{ github.event.inputs.increment }} python -m build --wheel --no-isolation
+        python -m build --wheel --no-isolation
         twine upload dist/*

--- a/.github/workflows/update_stubs.yml
+++ b/.github/workflows/update_stubs.yml
@@ -7,27 +7,34 @@ on:
   # If needed, allows to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions: {}
+
 env:
   FORCE_COLOR: 1
 
 jobs:
   build-and-upload:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{ github.repository == 'typeshed-internal/stub_uploader' || github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # 6.2.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.13'
       - name: Checkout main
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           path: main
+          # Needed to push updated commit records and changelogs.
+          persist-credentials: true
       - name: Checkout typeshed
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # 6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           repository: python/typeshed
           path: typeshed
+          persist-credentials: false
           # It is unlikely there will be more commits between two runs.
           # We could set this to 0 to fetch everything, but we want this to be fast.
           fetch-depth: 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,10 @@ repos:
     rev: 12e63946db2c5cfcc9030fac21c3883ba88c6ed8 # frozen: 0.38.0
     hooks:
       - id: check-github-workflows
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: cef8b8350da46d8114c7e6b7272aebdccdf193ce # frozen: v1.30.0
+    hooks:
+      - id: zizmor
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 4160603246a6b365d4a2af661c6d71b0a0f50478 # frozen: 26.5.1
     hooks:


### PR DESCRIPTION
Add [zizmor](https://docs.zizmor.sh/) as a SHA-pinned pre-commit hook and address its findings in our workflows. Zizmor statically checks GitHub Actions configurations for security issues including script injection, excessive token permissions, credential leakage, dangerous workflow triggers, and unpinned or known-vulnerable actions.

The [`template-injection`](https://docs.zizmor.sh/audits/#template-injection) fixes affect two manually dispatched publishing workflows:

- In `force_update.yml`, move `github.event.inputs.distribution` into the step's `DISTRIBUTION` environment variable and pass it to `stub_uploader.upload_some` as `"$DISTRIBUTION"`.
- In `test_api_token.yml`, move `github.event.inputs.increment` into the step's `PACKAGE_VERSION_INCREMENT` environment variable, which the package build already reads from its environment.

Previously, GitHub substituted these inputs directly into the `run` scripts before the shell parsed them. A supplied value containing shell syntax, such as a command substitution, could therefore execute commands in a step with access to the PyPI token; surrounding a GitHub expression with double quotes does not prevent that. Passing inputs through `env` keeps their contents out of the shell source. The quoted `"$DISTRIBUTION"` expansion passes the value as a single argument without interpreting its contents as shell commands, while the version increment reaches the build directly through its environment.

The remaining changes restrict GitHub token permissions to `contents: read`, granting `contents: write` only to jobs that push upload records, and disable checkout credential persistence except where those pushes require it. The API-token test has a documented exception to `use-trusted-publishing`, since switching that workflow to trusted publishing would defeat its purpose.

Action version comments now include the tags' `v` prefix, for example `# v6.0.3`, so zizmor can match them to the existing SHA pins. If we enable Dependabot or Renovate for this repository in the future, either will still update both the pinned action SHA and the adjacent version comment in this format. Both [Dependabot](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#github-actions) and [Renovate](https://docs.renovatebot.com/modules/manager/github-actions/#digest-pinning-and-updating) support it.
