### PR TITLE
Document optional dependencies for stub packages

### DIFF
--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -44,11 +44,6 @@ CHANGELOG = "CHANGELOG.md"
 
 SUFFIX = "-stubs"
 
-PARTIAL_STUBS_DESCRIPTION = """
-This stub package is marked as [partial](https://typing.python.org/en/latest/spec/distributing.html#partial-stub-packages).
-If you find that annotations are missing, feel free to contribute and help complete them.
-""".lstrip()
-
 PYPROJECT_TEMPLATE = dedent("""
 [build-system]
 build-backend = "setuptools.build_meta"
@@ -85,16 +80,6 @@ include-package-data = false
 {package_data}
 """).lstrip()
 
-NO_LONGER_UPDATED_TEMPLATE = """
-*Note:* `{stub_distribution}` is unmaintained and won't be updated.
-""".lstrip()
-
-OBSOLETE_SINCE_TEXT_TEMPLATE = """
-*Note:* The `{distribution}` package includes type annotations or type stubs
-since version {obsolete_since}. Please uninstall the `{stub_distribution}`
-package if you use this or a newer version.
-""".lstrip()
-
 DESCRIPTION_INTRO_TEMPLATE = """
 ## Typing stubs for {distribution}
 
@@ -104,6 +89,21 @@ to check code that uses `{distribution}`. This version of
 `{stub_distribution}` aims to provide accurate annotations for
 `{distribution}{typeshed_version_spec}`.
 """.strip()
+
+OBSOLETE_SINCE_TEXT_TEMPLATE = """
+*Note:* The `{distribution}` package includes type annotations or type stubs
+since version {obsolete_since}. Please uninstall the `{stub_distribution}`
+package if you use this or a newer version.
+""".lstrip()
+
+NO_LONGER_UPDATED_TEMPLATE = """
+*Note:* `{stub_distribution}` is unmaintained and won't be updated.
+""".lstrip()
+
+PARTIAL_STUBS_DESCRIPTION = """
+This stub package is marked as [partial](https://typing.python.org/en/latest/spec/distributing.html#partial-stub-packages).
+If you find that annotations are missing, feel free to contribute and help complete them.
+""".lstrip()
 
 DESCRIPTION_OUTRO_TEMPLATE = """
 This package is part of the [typeshed project](https://github.com/python/typeshed).
@@ -118,6 +118,18 @@ This package was tested with the following type checkers:
 
 It was generated from typeshed commit
 [`{commit}`](https://github.com/python/typeshed/commit/{commit}).
+""".strip()
+
+EXTRAS_SECTION_TEMPLATE = """
+## Optional dependencies
+
+Some stubs depend on third-party libraries that are not required by every user.
+The following extras are available:
+
+```console
+pip install '{stub_distribution}[all]' # installs all optional dependencies
+{extras_install_commands}
+```
 """.strip()
 
 
@@ -336,7 +348,7 @@ def is_ignored_distribution_file(entry: Path) -> bool:
 
 
 def generate_optional_dependencies_table(dependencies: Iterable[Dependency]) -> str:
-    """Generate the [project.optional-dependencies] table."""
+    """Generate the [project.optional-dependencies] table for pyproject.toml."""
     if not dependencies:
         return ""
 
@@ -433,6 +445,18 @@ def generate_long_description(
             ),
         )
     )
+    if metadata.optional_dependencies:
+        parts.append(
+            EXTRAS_SECTION_TEMPLATE.format(
+                stub_distribution=metadata.stub_distribution,
+                extras_install_commands="\n".join(
+                    f"pip install '{metadata.stub_distribution}"
+                    f"[{EXTERNAL_RUNTIME_REQ_MAP.get(dep.base_name, dep.base_name)}]' "
+                    f"# installs {dep}"
+                    for dep in metadata.optional_dependencies
+                ),
+            )
+        )
     return "\n\n".join(parts)
 
 

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -127,7 +127,7 @@ Some stubs depend on third-party libraries that are not required by every user.
 The following extras are available:
 
 ```console
-- pip install '{stub_distribution}[all]' # installs all optional dependencies
+pip install '{stub_distribution}[all]' # installs all optional dependencies
 {extras_install_commands}
 ```
 """.strip()
@@ -450,7 +450,7 @@ def generate_long_description(
             EXTRAS_SECTION_TEMPLATE.format(
                 stub_distribution=metadata.stub_distribution,
                 extras_install_commands="\n".join(
-                    f"- pip install '{metadata.stub_distribution}"
+                    f"pip install '{metadata.stub_distribution}"
                     f"[{EXTERNAL_RUNTIME_REQ_MAP.get(dep.base_name, dep.base_name)}]' "
                     f"# installs {dep}"
                     for dep in metadata.optional_dependencies

--- a/stub_uploader/build_wheel.py
+++ b/stub_uploader/build_wheel.py
@@ -127,7 +127,7 @@ Some stubs depend on third-party libraries that are not required by every user.
 The following extras are available:
 
 ```console
-pip install '{stub_distribution}[all]' # installs all optional dependencies
+- pip install '{stub_distribution}[all]' # installs all optional dependencies
 {extras_install_commands}
 ```
 """.strip()
@@ -450,7 +450,7 @@ def generate_long_description(
             EXTRAS_SECTION_TEMPLATE.format(
                 stub_distribution=metadata.stub_distribution,
                 extras_install_commands="\n".join(
-                    f"pip install '{metadata.stub_distribution}"
+                    f"- pip install '{metadata.stub_distribution}"
                     f"[{EXTERNAL_RUNTIME_REQ_MAP.get(dep.base_name, dep.base_name)}]' "
                     f"# installs {dep}"
                     for dep in metadata.optional_dependencies


### PR DESCRIPTION
* Example of generated list:
````
```console
pip install 'types-fake[all]' # installs all optional dependencies
pip install 'types-fake[numpy]' # installs numpy
pip install 'types-fake[requests]' # installs types-requests>=0.1
pip install 'types-fake[pandas]' # installs pandas-stubs
```
````
* Sort description templates by the order in which they are used